### PR TITLE
refactor(library): 프로젝트 생성 모달 삭제 및 즉시 생성 플로우 구현

### DIFF
--- a/.pr_modal_body.md
+++ b/.pr_modal_body.md
@@ -1,0 +1,10 @@
+## 변경 사항
+
+- **[NEW] CreateProjectModal**: 제목, 장르, 설명을 입력받아 새 프로젝트를 생성하는 모달 컴포넌트 추가. `react-hook-form`과 `zod`를 사용하여 유효성 검사를 수행합니다.
+- **[MODIFY] LibraryPage**: "새 작품 만들기" 버튼을 모달과 연동하고, 모달 컴포넌트를 통합했습니다.
+- **[FEAT] Navigation**: 프로젝트 생성 성공 시 즉시 해당 에디터 페이지로 이동합니다.
+
+## 기술적 세부사항
+
+- `shadcn/ui`의 Dialog, Input, Select, Textarea 컴포넌트 활용.
+- `useDocumentStore` (LocalRepository)를 통해 폴더(Project)와 루트 문서(Chapter)를 원자적으로 생성.

--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -17,7 +17,8 @@ import { Input } from "@/components/ui/input";
 import { BookCard, type ProjectStatus } from "@/components/library/BookCard";
 import { CreateBookCard } from "@/components/library/CreateBookCard";
 import { ImportBookCard } from "@/components/library/ImportBookCard";
-import { useUIStore, useAuthStore } from "@/stores";
+
+import { useAuthStore } from "@/stores";
 import type { Project } from "@/types";
 import { cn } from "@/lib/utils";
 import { useNavigate, Link } from "react-router-dom";
@@ -140,7 +141,7 @@ const mockProjects: ExtendedProject[] = [
 ];
 
 export default function LibraryPage() {
-  const { setCreateProjectModalOpen } = useUIStore();
+  const { _create } = useDocumentStore();
   const { user, logout } = useAuthStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
@@ -290,6 +291,59 @@ export default function LibraryPage() {
 
   const handleImportClick = () => {
     fileInputRef.current?.click();
+  };
+
+  const handleCreateProject = () => {
+    const now = new Date().toISOString();
+    const newProjectId = `project-${Date.now()}`;
+
+    // 1. 프로젝트(폴더) 생성
+    _create({
+      id: newProjectId,
+      projectId: newProjectId,
+      type: "folder",
+      title: "새 작품",
+      content: "",
+      synopsis: "",
+      order: 0,
+      metadata: {
+        status: "draft",
+        wordCount: 0,
+        includeInCompile: true,
+        keywords: ["auto-genre"],
+        notes: "",
+      },
+      characterIds: [],
+      foreshadowingIds: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // 2. 초기 챕터(문서) 생성
+    _create({
+      id: `doc-${Date.now()}`,
+      projectId: newProjectId,
+      parentId: newProjectId,
+      type: "text",
+      title: "1화",
+      content: "",
+      synopsis: "",
+      order: 0,
+      metadata: {
+        status: "draft",
+        wordCount: 0,
+        includeInCompile: true,
+        keywords: [],
+        notes: "",
+      },
+      characterIds: [],
+      foreshadowingIds: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // 3. 에디터로 이동
+    navigate(`/projects/${newProjectId}/editor`);
   };
 
   const containerVariants = {
@@ -508,7 +562,7 @@ export default function LibraryPage() {
 
           {/* Create New Book Card */}
           <motion.div variants={itemVariants} className="h-full min-h-[320px]">
-            <CreateBookCard onClick={() => setCreateProjectModalOpen(true)} />
+            <CreateBookCard onClick={handleCreateProject} />
           </motion.div>
 
           {/* Import Book Card */}
@@ -566,11 +620,7 @@ export default function LibraryPage() {
               <br />
               복선 관리, AI 분석 등 StoLink의 모든 기능을 경험할 수 있습니다.
             </p>
-            <Button
-              size="lg"
-              className="gap-2"
-              onClick={() => setCreateProjectModalOpen(true)}
-            >
+            <Button size="lg" className="gap-2" onClick={handleCreateProject}>
               <FileText className="w-5 h-5" />새 작품 만들기
             </Button>
           </div>
@@ -579,6 +629,8 @@ export default function LibraryPage() {
 
       {/* Footer */}
       <Footer />
+
+      {/* Modals */}
     </div>
   );
 }

--- a/src/stores/useUIStore.ts
+++ b/src/stores/useUIStore.ts
@@ -1,39 +1,41 @@
-import { create } from 'zustand';
+import { create } from "zustand";
 
 interface UIState {
   // Sidebar states
   leftSidebarOpen: boolean;
   rightSidebarOpen: boolean;
-  rightSidebarTab: 'foreshadowing' | 'ai' | 'consistency';
+  rightSidebarTab: "foreshadowing" | "ai" | "consistency";
 
   // Modal states
-  createProjectModalOpen: boolean;
+
   createChapterModalOpen: boolean;
 
   // Theme
-  theme: 'light' | 'dark';
+  theme: "light" | "dark";
 
   // Actions
   toggleLeftSidebar: () => void;
   toggleRightSidebar: () => void;
-  setRightSidebarTab: (tab: 'foreshadowing' | 'ai' | 'consistency') => void;
-  setCreateProjectModalOpen: (open: boolean) => void;
+  setRightSidebarTab: (tab: "foreshadowing" | "ai" | "consistency") => void;
+
   setCreateChapterModalOpen: (open: boolean) => void;
-  setTheme: (theme: 'light' | 'dark') => void;
+  setTheme: (theme: "light" | "dark") => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
   leftSidebarOpen: true,
   rightSidebarOpen: true,
-  rightSidebarTab: 'foreshadowing',
-  createProjectModalOpen: false,
-  createChapterModalOpen: false,
-  theme: 'light',
+  rightSidebarTab: "foreshadowing",
 
-  toggleLeftSidebar: () => set((state) => ({ leftSidebarOpen: !state.leftSidebarOpen })),
-  toggleRightSidebar: () => set((state) => ({ rightSidebarOpen: !state.rightSidebarOpen })),
+  createChapterModalOpen: false,
+  theme: "light",
+
+  toggleLeftSidebar: () =>
+    set((state) => ({ leftSidebarOpen: !state.leftSidebarOpen })),
+  toggleRightSidebar: () =>
+    set((state) => ({ rightSidebarOpen: !state.rightSidebarOpen })),
   setRightSidebarTab: (tab) => set({ rightSidebarTab: tab }),
-  setCreateProjectModalOpen: (open) => set({ createProjectModalOpen: open }),
+
   setCreateChapterModalOpen: (open) => set({ createChapterModalOpen: open }),
   setTheme: (theme) => set({ theme }),
 }));


### PR DESCRIPTION
## 변경 사항

- **[DEL] CreateProjectModal.tsx**: 복잡성을 줄이고 UX를 단순화하기 위해 모달 컴포넌트를 삭제했습니다.
- **[MOD] LibraryPage.tsx**: "새 작품 만들기" 버튼 클릭 시 모달 대신 즉시 프로젝트를 생성하고 에디터로 이동하도록 로직을 변경했습니다.
- **[MOD] useUIStore.ts**: 불필요해진 모달 관련 상태를 제거했습니다.

## 상세 내용

기존의 장르/설명 입력 단계를 제거하고, 즉시 "새 작품"을 생성하여 에디터 진입 장벽을 낮췄습니다. (Text-to-Data 철학 반영)
