### PR TITLE
fix: 로고 링크 비활성화 및 로그아웃 리다이렉트 수정

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,7 +31,7 @@ api.interceptors.response.use(
     if (error.response?.status === 401) {
       // Token expired, logout user
       useAuthStore.getState().logout();
-      window.location.href = "/auth";
+      window.location.href = "/";
     }
     return Promise.reject(error);
   }

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -68,7 +68,9 @@ export function ProjectLayout() {
 
   // 현재 프로젝트 제목 (첫 번째 폴더 또는 기본값)
   const projectTitle = useMemo(() => {
-    const folder = localDocuments?.find((doc: Document) => doc.type === "folder");
+    const folder = localDocuments?.find(
+      (doc: Document) => doc.type === "folder"
+    );
     return folder?.title || "내 작품";
   }, [localDocuments]);
 
@@ -114,11 +116,7 @@ export function ProjectLayout() {
                 <span className="text-sm font-medium">서재</span>
               </button>
               <div className="h-6 w-px bg-stone-200" />
-              <img
-                src={mainLogo}
-                alt="Sto-Link"
-                className="h-12 w-auto"
-              />
+              <img src={mainLogo} alt="Sto-Link" className="h-12 w-auto" />
             </div>
 
             <div className="flex flex-col">
@@ -151,7 +149,7 @@ export function ProjectLayout() {
                     "flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200",
                     isActive
                       ? "bg-white text-sage-600 shadow-sm border-stone-200"
-                      : "text-muted-foreground hover:text-foreground hover:bg-stone-200/50",
+                      : "text-muted-foreground hover:text-foreground hover:bg-stone-200/50"
                   )
                 }
               >

--- a/src/components/layouts/ProtectedLayout.tsx
+++ b/src/components/layouts/ProtectedLayout.tsx
@@ -1,11 +1,11 @@
-import { Navigate, Outlet } from 'react-router-dom';
-import { useAuthStore } from '@/stores';
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuthStore } from "@/stores";
 
 export function ProtectedLayout() {
   const { isAuthenticated } = useAuthStore();
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return <Navigate to="/" replace />;
   }
 
   return <Outlet />;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -85,13 +85,13 @@ export function useLogout() {
     onSuccess: () => {
       logout();
       queryClient.clear(); // Clear all cached data
-      navigate("/auth");
+      navigate("/");
     },
     onError: () => {
       // Even if API call fails, clear local auth state
       logout();
       queryClient.clear();
-      navigate("/auth");
+      navigate("/");
     },
   });
 }

--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -431,16 +431,11 @@ export default function LibraryPage() {
           <div className="flex flex-col gap-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <Link
-                  to="/"
-                  className="flex items-center hover:opacity-80 transition-opacity"
-                >
-                  <img
-                    src="/assets/main_logo.png"
-                    alt="Sto-Link"
-                    className="h-16 w-auto"
-                  />
-                </Link>
+                <img
+                  src="/assets/main_logo.png"
+                  alt="Sto-Link"
+                  className="h-16 w-auto"
+                />
               </div>
 
               <div className="flex items-center gap-3">


### PR DESCRIPTION
## 📋 변경 사항

- **로고 네비게이션 비활성화**: 서재 페이지 및 프로젝트 레이아웃의 로고에서 링크 기능을 제거했습니다. (정적 이미지로 변경)
- **로그아웃 리다이렉션 경로 수정**: 로그아웃 시 로그인 페이지(`/auth`)가 아닌 랜딩 페이지(`/`)로 이동하도록 수정했습니다.
- **인증Layout 및 API 인터셉터 수정**: 인증되지 않은 접근이나 세션 만료 시에도 랜딩 페이지(`/`)로 리다이렉트되도록 개선했습니다.

## 📁 변경된 파일

- `src/api/client.ts`
- `src/components/layouts/ProjectLayout.tsx`
- `src/components/layouts/ProtectedLayout.tsx`
- `src/hooks/useAuth.ts`
- `src/pages/library/LibraryPage.tsx`
- `src/pages/auth/AuthPage.tsx`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
