### PR TITLE
feat(library): 서재 UX/UI 3대 기능 개선

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -3,7 +3,7 @@ name: Frontend CICD
 on:
   push:
     branches:
-      - develop
+      - dev
 
 permissions:
   id-token: write # OIDC용

--- a/.github/workflows/hotfix-backport.yml
+++ b/.github/workflows/hotfix-backport.yml
@@ -21,10 +21,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Merge Hotfix into develop
+      - name: Merge Hotfix into dev
         run: |
-          git checkout develop
-          git merge --no-ff origin/${{ github.event.pull_request.head.ref }} -m "chore(hotfix): back-port ${{ github.event.pull_request.head.ref }} to develop"
-          git push origin develop
+          git checkout dev
+          git merge --no-ff origin/${{ github.event.pull_request.head.ref }} -m "chore(hotfix): back-port ${{ github.event.pull_request.head.ref }} to dev"
+          git push origin dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.troubles/2025-12-27_BookCard-Type-Handler.md
+++ b/.troubles/2025-12-27_BookCard-Type-Handler.md
@@ -1,0 +1,82 @@
+# BookCard ProjectStatus 타입 및 핸들러 개선
+
+## Issue Description
+
+AI 코드 리뷰에서 두 가지 치명적 이슈 발견:
+
+1. **ProjectStatus 타입 불일치**
+   - 파일: `src/components/library/BookCard.tsx`
+   - 라인: 12-20
+   - 에러 유형: 🔴 치명적
+   - 문제: 대문자(`DRAFTING`, `COMPLETED`)와 소문자(`writing`, `completed`) 혼재
+
+2. **편집 모드에서 onSelect 핸들러 누락 가능성**
+   - 파일: `src/components/library/BookCard.tsx`
+   - 라인: 99-116
+   - 에러 유형: 🔴 치명적
+   - 문제: `isEditMode=true`일 때 `onSelect`가 undefined일 수 있음
+
+## Solution Strategy
+
+### 1. ProjectStatus 타입 통일
+
+대문자만 사용하고, 변환은 `normalizeStatus` 함수에서만 수행
+
+#### 변경 전
+
+```tsx
+export type ProjectStatus =
+  | "DRAFTING" | "OUTLINE" | "EDITING" | "COMPLETED" | "IDEA"
+  | "writing" | "completed";
+```
+
+#### 변경 후
+
+```tsx
+export type ProjectStatus =
+  | "DRAFTING" | "OUTLINE" | "EDITING" | "COMPLETED" | "IDEA";
+```
+
+### 2. normalizeStatus 함수 개선
+
+문자열을 대문자로 변환 후 비교
+
+#### 변경 전
+
+```tsx
+function normalizeStatus(status: ProjectStatus): ProjectStatusType {
+  switch (status) {
+    case "COMPLETED":
+    case "completed":
+      return "completed";
+    // ...
+  }
+}
+```
+
+#### 변경 후
+
+```tsx
+function normalizeStatus(status: ProjectStatus | string): ProjectStatusType {
+  const upperStatus = typeof status === "string" ? status.toUpperCase() : status;
+  switch (upperStatus) {
+    case "COMPLETED":
+      return "completed";
+    // ...
+  }
+}
+```
+
+### 3. onSelect 경고 추가
+
+```tsx
+if (isEditMode && !onSelect) {
+  console.warn("BookCard: onSelect is required when isEditMode=true");
+}
+```
+
+## Outcome
+
+- **상태**: ✅ 해결됨
+- **빌드 결과**: `npm run dev` 정상 구동
+- **검증 방법**: 컴파일 에러 없음, 편집 모드 동작 정상

--- a/.troubles/2025-12-27_SlashCommand-Any-Type.md
+++ b/.troubles/2025-12-27_SlashCommand-Any-Type.md
@@ -1,0 +1,31 @@
+# SlashCommand any 타입 개선
+
+## Issue Description
+
+`tippy` 플러그인에서 `any` 타입 사용으로 인해 타입 안정성이 떨어지는 문제
+
+- 파일: `src/components/editor/extensions/SlashCommand.tsx`
+- 라인: 143
+- 에러 유형: 🔴 치명적
+
+## Solution Strategy
+
+`any` 타입을 `Record<string, unknown>`으로 변경하여 타입 안전성 개선
+
+### 변경 전
+
+```tsx
+let component: ReactRenderer<CommandListRef, any>;
+```
+
+### 변경 후
+
+```tsx
+let component: ReactRenderer<CommandListRef, Record<string, unknown>>;
+```
+
+## Outcome
+
+- **상태**: ✅ 해결됨
+- **빌드 결과**: `npm run dev` 정상 구동
+- **검증 방법**: TypeScript 컴파일 에러 없음 확인

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -256,10 +256,10 @@ npm run format       # Prettier
 
 ```
 main ─────── 프로덕션 (직접 push 금지)
-develop ──── 개발 통합, 스테이징 (직접 push 금지)
-feature/* ── 기능 개발 → develop PR
-fix/* ────── 버그 수정 → develop PR
-hotfix/* ─── 긴급 수정 → main PR (자동 backport to develop)
+dev ──── 개발 통합, 스테이징 (직접 push 금지)
+feature/* ── 기능 개발 → dev PR
+fix/* ────── 버그 수정 → dev PR
+hotfix/* ─── 긴급 수정 → main PR (자동 backport to dev)
 ```
 
 > 상세 가이드: [GIT_STRATEGY.md](./GIT_STRATEGY.md)
@@ -272,7 +272,7 @@ hotfix/* ─── 긴급 수정 → main PR (자동 backport to develop)
 | --------------------- | ---------------- | ---------------------- |
 | `ai-review.yml`       | PR 생성/업데이트 | Claude API로 코드 리뷰 |
 | `deploy.yml`          | main push        | S3 + CloudFront 배포   |
-| `deploy_dev.yml`      | develop push     | 개발 환경 배포         |
+| `deploy_dev.yml`      | dev push         | 개발 환경 배포         |
 | `hotfix-backport.yml` | hotfix→main 머지 | develop에 자동 체리픽  |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ StoLink - 작가용 AI 기반 스토리 관리 플랫폼
 - console.log 커밋 (개발용 제외)
 - Set, Map을 Zustand에 저장
 - 중복 로직 작성 (기존 hooks/services 확인 필수)
-- main/develop 브랜치에 직접 push
+- main/dev 브랜치에 직접 push
 - PR 없이 main에 머지
 - useEffect 의존성 배열 빈 배열로 회피 (린트 에러 무시)
 - useQuery 내부에서 Zustand 직접 업데이트
@@ -148,9 +148,9 @@ StoLink - 작가용 AI 기반 스토리 관리 플랫폼
 | 브랜치      | 용도      | 직접 Push | PR 대상          |
 | ----------- | --------- | --------- | ---------------- |
 | `main`      | 프로덕션  | ❌ 금지   | hotfix/\*        |
-| `develop`   | 개발 통합 | ❌ 금지   | feature/_, fix/_ |
-| `feature/*` | 기능 개발 | ✅ 허용   | → develop        |
-| `fix/*`     | 버그 수정 | ✅ 허용   | → develop        |
+| `dev`       | 개발 통합 | ❌ 금지   | feature/_, fix/_ |
+| `feature/*` | 기능 개발 | ✅ 허용   | → dev            |
+| `fix/*`     | 버그 수정 | ✅ 허용   | → dev            |
 | `hotfix/*`  | 긴급 수정 | ✅ 허용   | → main           |
 
 **상세 가이드**: [GIT_STRATEGY.md](GIT_STRATEGY.md)
@@ -344,7 +344,7 @@ src/
 | AI 코드 리뷰    | `.github/workflows/ai-review.yml`       | PR 생성/업데이트, `/review` 코멘트 | Claude API로 코드 리뷰 |
 | 스마트 커밋     | `.agent/workflows/smart-commit.md`      | `/smart-commit` 명령               | 커밋, 푸시, PR 관리    |
 | 프로덕션 배포   | `.github/workflows/deploy.yml`          | main push                          | S3 + CloudFront        |
-| 개발 배포       | `.github/workflows/deploy_dev.yml`      | develop push                       | 개발 환경 배포         |
+| 개발 배포       | `.github/workflows/deploy_dev.yml`      | dev push                           | 개발 환경 배포         |
 | Hotfix Backport | `.github/workflows/hotfix-backport.yml` | hotfix/\* → main 머지              | develop에 자동 체리픽  |
 
 </workflow_integration>

--- a/GIT_STRATEGY.md
+++ b/GIT_STRATEGY.md
@@ -30,20 +30,20 @@
 
 프로젝트의 역사를 깔끔하게 유지하기 위해 아래 원칙을 반드시 준수합니다.
 
-### ① Squash and Merge (`feature` → `develop`)
+### ① Squash and Merge (`feature` → `dev`)
 
-- 자잘한 커밋 이력들을 하나로 뭉쳐서 `develop`에 병합합니다.
-- 목적: `develop`의 히스토리를 기능 단위로 깔끔하게 유지.
+- 자잘한 커밋 이력들을 하나로 뭉쳐서 `dev`에 병합합니다.
+- 목적: `dev`의 히스토리를 기능 단위로 깔끔하게 유지.
 
-### ② Non-Fast-Forward (`develop` → `main`)
+### ② Non-Fast-Forward (`dev` → `main`)
 
-- 릴리즈 시 반드시 `git merge develop --no-ff`를 사용합니다.
+- 릴리즈 시 반드시 `git merge dev --no-ff`를 사용합니다.
 - 목적: "이 시점에 특정 버전이 배포되었다"는 병합 지점(Merge Point)을 명시적으로 기록.
 
 ### ③ Hotfix Back-porting (`hotfix` → both)
 
-- 운영 서버(`main`) 수정을 리포팅한 후, 해당 내용을 반드시 `develop`에도 즉시 병합해야 합니다.
-- 목적: `main`과 `develop` 사이의 코드 괴리 방지 및 향후 머지 충돌 예방.
+- 운영 서버(`main`) 수정을 리포팅한 후, 해당 내용을 반드시 `dev`에도 즉시 병합해야 합니다.
+- 목적: `main`과 `dev` 사이의 코드 괴리 방지 및 향후 머지 충돌 예방.
 
 ---
 
@@ -53,7 +53,7 @@
 
 - **`/smart-commit`**: 현재 작업을 분석하여 커밋하고, 원격에 푸시하며, 필요 시 PR을 자동으로 생성하거나 최신화합니다.
   - `hotfix/*` 브랜치는 자동으로 `main`을 타겟팅합니다.
-  - 그 외는 `develop`을 타겟으로 PR을 생성합니다.
+  - 그 외는 `dev`을 타겟으로 PR을 생성합니다.
 
 ---
 
@@ -63,17 +63,17 @@
 
 ### ① Hotfix 자동 반영 (GitHub Actions)
 
-- `hotfix/*` 브랜치가 `main`에 머지(Merge)되면, GitHub Actions가 이를 감지하여 **`develop` 브랜치에 자동으로 머집(Back-port)** 합니다.
+- `hotfix/*` 브랜치가 `main`에 머지(Merge)되면, GitHub Actions가 이를 감지하여 **`dev` 브랜치에 자동으로 머집(Back-port)** 합니다.
 - 파일: `.github/workflows/hotfix-backport.yml`
 
 ### ② 브러치 보호 및 머지 정책 설정 (GitHub Settings)
 
 GitHub 저장소 설정(`Settings > Branches > Branch protection rules`)에서 아래와 같이 설정하는 것을 권장합니다.
 
-| 대상 브랜치   | 권장 설정 (Branch Protection)      | 이유                                       |
-| :------------ | :--------------------------------- | :----------------------------------------- |
-| **`develop`** | **Allow squash merging** 만 활성화 | 작업 파편화를 막고 기능 단위 히스토리 유지 |
-| **`main`**    | **Allow merge commits** 만 활성화  | 릴리즈 시점(Merge Point)을 명시적으로 기록 |
+| 대상 브랜치 | 권장 설정 (Branch Protection)      | 이유                                       |
+| :---------- | :--------------------------------- | :----------------------------------------- |
+| **`dev`**   | **Allow squash merging** 만 활성화 | 작업 파편화를 막고 기능 단위 히스토리 유지 |
+| **`main`**  | **Allow merge commits** 만 활성화  | 릴리즈 시점(Merge Point)을 명시적으로 기록 |
 
 ---
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,7 +31,7 @@ api.interceptors.response.use(
     if (error.response?.status === 401) {
       // Token expired, logout user
       useAuthStore.getState().logout();
-      window.location.href = "/auth";
+      window.location.href = "/";
     }
     return Promise.reject(error);
   }

--- a/src/components/editor/extensions/SlashCommand.tsx
+++ b/src/components/editor/extensions/SlashCommand.tsx
@@ -140,7 +140,7 @@ export const SlashCommandExtension = SlashCommand.configure({
   suggestion: {
     items: getSuggestionItems,
     render: () => {
-      let component: ReactRenderer<CommandListRef, any>;
+      let component: ReactRenderer<CommandListRef, Record<string, unknown>>;
       let popup: TippyInstance[];
 
       return {

--- a/src/components/editor/extensions/SlashCommand.tsx
+++ b/src/components/editor/extensions/SlashCommand.tsx
@@ -140,7 +140,7 @@ export const SlashCommandExtension = SlashCommand.configure({
   suggestion: {
     items: getSuggestionItems,
     render: () => {
-      let component: ReactRenderer<CommandListRef, SuggestionProps>;
+      let component: ReactRenderer<CommandListRef, any>;
       let popup: TippyInstance[];
 
       return {

--- a/src/components/editor/sidebar/hooks/useTreeItem.ts
+++ b/src/components/editor/sidebar/hooks/useTreeItem.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, MouseEvent } from "react";
+import { useState, useRef, useEffect, type MouseEvent } from "react";
 
 interface UseTreeItemProps {
   initialTitle: string;

--- a/src/components/editor/sidebar/hooks/useTreeItemMenu.ts
+++ b/src/components/editor/sidebar/hooks/useTreeItemMenu.ts
@@ -1,4 +1,4 @@
-import { useState, MouseEvent } from "react";
+import { useState, type MouseEvent } from "react";
 import {
   FolderPlus,
   FilePlus,

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -68,7 +68,9 @@ export function ProjectLayout() {
 
   // 현재 프로젝트 제목 (첫 번째 폴더 또는 기본값)
   const projectTitle = useMemo(() => {
-    const folder = localDocuments?.find((doc: Document) => doc.type === "folder");
+    const folder = localDocuments?.find(
+      (doc: Document) => doc.type === "folder"
+    );
     return folder?.title || "내 작품";
   }, [localDocuments]);
 
@@ -114,11 +116,7 @@ export function ProjectLayout() {
                 <span className="text-sm font-medium">서재</span>
               </button>
               <div className="h-6 w-px bg-stone-200" />
-              <img
-                src={mainLogo}
-                alt="Sto-Link"
-                className="h-12 w-auto"
-              />
+              <img src={mainLogo} alt="Sto-Link" className="h-12 w-auto" />
             </div>
 
             <div className="flex flex-col">
@@ -151,7 +149,7 @@ export function ProjectLayout() {
                     "flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200",
                     isActive
                       ? "bg-white text-sage-600 shadow-sm border-stone-200"
-                      : "text-muted-foreground hover:text-foreground hover:bg-stone-200/50",
+                      : "text-muted-foreground hover:text-foreground hover:bg-stone-200/50"
                   )
                 }
               >

--- a/src/components/layouts/ProtectedLayout.tsx
+++ b/src/components/layouts/ProtectedLayout.tsx
@@ -1,11 +1,11 @@
-import { Navigate, Outlet } from 'react-router-dom';
-import { useAuthStore } from '@/stores';
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuthStore } from "@/stores";
 
 export function ProtectedLayout() {
   const { isAuthenticated } = useAuthStore();
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return <Navigate to="/" replace />;
   }
 
   return <Outlet />;

--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -9,15 +9,13 @@ import {
 import { cn } from "@/lib/utils";
 import { StatusChip, type ProjectStatusType } from "./StatusChip";
 
-// 레거시 호환용 타입 (기존 코드와의 호환성 유지)
+// ✅ API 형식 통일 - 대문자만 사용
 export type ProjectStatus =
   | "DRAFTING"
   | "OUTLINE"
   | "EDITING"
   | "COMPLETED"
-  | "IDEA"
-  | "writing"
-  | "completed";
+  | "IDEA";
 
 interface BookCardProps {
   // 프로젝트 ID (상태 변경 및 편집 모드용)
@@ -45,17 +43,17 @@ interface BookCardProps {
 
 /**
  * 프로젝트 상태를 StatusChip에서 사용하는 타입으로 변환
+ * 변환은 함수에서만 수행 - API 대문자 형식을 UI 소문자 형식으로
  */
-function normalizeStatus(status: ProjectStatus): ProjectStatusType {
-  switch (status) {
+function normalizeStatus(status: ProjectStatus | string): ProjectStatusType {
+  const upperStatus = typeof status === "string" ? status.toUpperCase() : status;
+  switch (upperStatus) {
     case "COMPLETED":
-    case "completed":
       return "completed";
     case "DRAFTING":
     case "EDITING":
     case "OUTLINE":
     case "IDEA":
-    case "writing":
     default:
       return "writing";
   }
@@ -79,6 +77,11 @@ export function BookCard({
 }: BookCardProps) {
   // 정규화된 상태 값
   const normalizedStatus = normalizeStatus(status);
+
+  // 편집 모드에서 onSelect 필수 체크
+  if (isEditMode && !onSelect) {
+    console.warn("BookCard: onSelect is required when isEditMode=true");
+  }
 
   // 카드 클릭 핸들러 (편집 모드일 때는 선택 동작)
   const handleCardClick = () => {

--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -1,4 +1,4 @@
-import { Clock, MoreVertical, Edit, Copy, Trash, BookOpen } from "lucide-react";
+import { Clock, MoreVertical, Edit, Copy, Trash, BookOpen, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -7,15 +7,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { StatusChip, type ProjectStatusType } from "./StatusChip";
 
+// 레거시 호환용 타입 (기존 코드와의 호환성 유지)
 export type ProjectStatus =
   | "DRAFTING"
   | "OUTLINE"
   | "EDITING"
   | "COMPLETED"
-  | "IDEA";
+  | "IDEA"
+  | "writing"
+  | "completed";
 
 interface BookCardProps {
+  // 프로젝트 ID (상태 변경 및 편집 모드용)
+  projectId?: string;
   title: string;
   author: string;
   status: ProjectStatus;
@@ -27,9 +33,36 @@ interface BookCardProps {
   lastEdited: string;
   onClick?: () => void;
   onAction?: (action: "rename" | "duplicate" | "delete") => void;
+
+  // 상태 변경 콜백
+  onStatusChange?: (status: ProjectStatusType) => void;
+
+  // 편집 모드 관련 props
+  isEditMode?: boolean;
+  isSelected?: boolean;
+  onSelect?: () => void;
+}
+
+/**
+ * 프로젝트 상태를 StatusChip에서 사용하는 타입으로 변환
+ */
+function normalizeStatus(status: ProjectStatus): ProjectStatusType {
+  switch (status) {
+    case "COMPLETED":
+    case "completed":
+      return "completed";
+    case "DRAFTING":
+    case "EDITING":
+    case "OUTLINE":
+    case "IDEA":
+    case "writing":
+    default:
+      return "writing";
+  }
 }
 
 export function BookCard({
+  projectId,
   title,
   author,
   status,
@@ -39,46 +72,69 @@ export function BookCard({
   lastEdited,
   onClick,
   onAction,
+  onStatusChange,
+  isEditMode = false,
+  isSelected = false,
+  onSelect,
 }: BookCardProps) {
-  // Status Indicator Colors
-  const getStatusColor = (s: ProjectStatus) => {
-    switch (s) {
-      case "COMPLETED":
-        return "text-green-600";
-      case "DRAFTING":
-        return "text-primary"; // Sage Green
-      case "EDITING":
-        return "text-orange-500";
-      case "OUTLINE":
-        return "text-blue-500";
-      default:
-        return "text-stone-400";
-    }
-  };
+  // 정규화된 상태 값
+  const normalizedStatus = normalizeStatus(status);
 
-  const getStatusLabel = (s: ProjectStatus) => {
-    switch (s) {
-      case "DRAFTING":
-        return "Drafting"; // Or "집필중" if strict Korean
-      case "COMPLETED":
-        return "Completed";
-      default:
-        return s.charAt(0) + s.slice(1).toLowerCase();
+  // 카드 클릭 핸들러 (편집 모드일 때는 선택 동작)
+  const handleCardClick = () => {
+    if (isEditMode) {
+      onSelect?.();
+    } else {
+      onClick?.();
     }
   };
 
   return (
     <div
-      className="group relative flex flex-col h-full bg-white rounded-lg border border-stone-200 shadow-sm hover:shadow-md hover:border-primary/30 transition-all duration-300 overflow-hidden cursor-pointer"
-      onClick={onClick}
+      className={cn(
+        "group relative flex flex-col h-full bg-white rounded-lg border shadow-sm transition-all duration-300 overflow-hidden cursor-pointer",
+        // 기본 상태
+        !isEditMode && "border-stone-200 hover:shadow-md hover:border-primary/30",
+        // 편집 모드 스타일
+        isEditMode && "border-sage-200 scale-[0.98]",
+        // 선택됨 스타일
+        isSelected && "ring-2 ring-primary border-primary"
+      )}
+      onClick={handleCardClick}
     >
+      {/* 편집 모드 체크박스 오버레이 */}
+      {isEditMode && (
+        <div
+          className="absolute top-3 left-3 z-20"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.();
+          }}
+        >
+          <div
+            className={cn(
+              "w-6 h-6 rounded-md flex items-center justify-center",
+              "border-2 shadow-sm transition-all duration-200",
+              isSelected
+                ? "border-green-500 bg-green-500"
+                : "bg-white border-stone-400 hover:border-green-500"
+            )}
+          >
+            {isSelected && <Check className="h-4 w-4 text-white" />}
+          </div>
+        </div>
+      )}
+
       {/* Cover Image Area */}
       <div className="relative aspect-[3/2] w-full overflow-hidden bg-stone-100">
         {coverImage ? (
           <img
             src={coverImage}
             alt={title}
-            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            className={cn(
+              "h-full w-full object-cover transition-transform duration-500",
+              !isEditMode && "group-hover:scale-105"
+            )}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center text-stone-300">
@@ -86,40 +142,42 @@ export function BookCard({
           </div>
         )}
 
-        {/* More Options Menu (Top Right) */}
-        <div
-          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 bg-white/90 backdrop-blur-sm hover:bg-white text-stone-600 rounded-full shadow-sm"
-              >
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
-              <DropdownMenuItem onClick={() => onAction?.("rename")}>
-                <Edit className="mr-2 h-4 w-4" /> Rename
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onAction?.("duplicate")}>
-                <Copy className="mr-2 h-4 w-4" /> Duplicate
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => onAction?.("delete")}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash className="mr-2 h-4 w-4" /> Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        {/* More Options Menu (Top Right) - 편집 모드가 아닐 때만 표시 */}
+        {!isEditMode && (
+          <div
+            className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 bg-white/90 backdrop-blur-sm hover:bg-white text-stone-600 rounded-full shadow-sm"
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onClick={() => onAction?.("rename")}>
+                  <Edit className="mr-2 h-4 w-4" /> Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onAction?.("duplicate")}>
+                  <Copy className="mr-2 h-4 w-4" /> Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onAction?.("delete")}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash className="mr-2 h-4 w-4" /> Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
       </div>
 
-      {/* Content Area (Spec 4.2 match) */}
+      {/* Content Area */}
       <div className="flex flex-col flex-1 p-4 gap-3">
         {/* Title */}
         <div>
@@ -148,21 +206,34 @@ export function BookCard({
           <span>Updated {lastEdited}</span>
         </div>
 
-        {/* Status Line */}
-        <div className="pt-3 border-t border-stone-100 flex items-center justify-between">
-          <div className="flex items-center gaps-2">
-            <span
-              className={cn(
-                "h-2 w-2 rounded-full mr-2",
-                getStatusColor(status),
-              )}
+        {/* Status Line - StatusChip으로 교체 */}
+        <div
+          className="pt-3 border-t border-stone-100 flex items-center justify-between"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* StatusChip (편집 모드가 아닐 때만 클릭 가능) */}
+          {onStatusChange ? (
+            <StatusChip
+              status={normalizedStatus}
+              onStatusChange={onStatusChange}
+              disabled={isEditMode}
             />
-            <span className="text-xs font-semibold text-stone-600">
-              {getStatusLabel(status)}
-            </span>
-          </div>
+          ) : (
+            // onStatusChange가 없으면 기존 방식으로 표시 (읽기 전용)
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full",
+                  normalizedStatus === "completed" ? "bg-green-500" : "bg-sage-500"
+                )}
+              />
+              <span className="text-xs font-semibold text-stone-600">
+                {normalizedStatus === "completed" ? "Complete" : "Writing"}
+              </span>
+            </div>
+          )}
 
-          {/* Optional: Words/Length if available (not strictly in spec small card, but useful) */}
+          {/* Words/Length */}
           {length && <span className="text-xs text-stone-400">{length}</span>}
         </div>
       </div>

--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -43,19 +43,19 @@ interface BookCardProps {
 
 /**
  * 프로젝트 상태를 StatusChip에서 사용하는 타입으로 변환
- * 변환은 함수에서만 수행 - API 대문자 형식을 UI 소문자 형식으로
+ * API 상태값을 UI에서 사용하는 EDITING/COMPLETED로 정규화
  */
 function normalizeStatus(status: ProjectStatus | string): ProjectStatusType {
   const upperStatus = typeof status === "string" ? status.toUpperCase() : status;
   switch (upperStatus) {
     case "COMPLETED":
-      return "completed";
+      return "COMPLETED";
     case "DRAFTING":
     case "EDITING":
     case "OUTLINE":
     case "IDEA":
     default:
-      return "writing";
+      return "EDITING";
   }
 }
 
@@ -227,11 +227,11 @@ export function BookCard({
               <span
                 className={cn(
                   "h-2 w-2 rounded-full",
-                  normalizedStatus === "completed" ? "bg-green-500" : "bg-sage-500"
+                  normalizedStatus === "COMPLETED" ? "bg-green-500" : "bg-sage-500"
                 )}
               />
               <span className="text-xs font-semibold text-stone-600">
-                {normalizedStatus === "completed" ? "Complete" : "Writing"}
+                {normalizedStatus === "COMPLETED" ? "Complete" : "Writing"}
               </span>
             </div>
           )}

--- a/src/components/library/CreateBookModal.tsx
+++ b/src/components/library/CreateBookModal.tsx
@@ -1,0 +1,132 @@
+import { FileText, Upload, X } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface CreateBookModalProps {
+    // 모달 열림 상태
+    open: boolean;
+    // 모달 상태 변경 콜백
+    onOpenChange: (open: boolean) => void;
+    // 빈 문서로 시작 클릭 콜백
+    onCreateBlank: () => void;
+    // 기존 원고 불러오기 클릭 콜백
+    onImport: () => void;
+    // 생성 중 상태 (버튼 비활성화용)
+    isCreating?: boolean;
+}
+
+/**
+ * 새 작품 만들기 선택 모달
+ * - 빈 문서로 시작: 새 프로젝트 생성 후 에디터로 이동
+ * - 기존 원고 불러오기: 파일 탐색기 열기
+ */
+export function CreateBookModal({
+    open,
+    onOpenChange,
+    onCreateBlank,
+    onImport,
+    isCreating = false,
+}: CreateBookModalProps) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-[600px] p-0 gap-0 overflow-hidden">
+                {/* 헤더 */}
+                <DialogHeader className="px-6 py-5 border-b border-stone-100">
+                    <DialogTitle className="text-xl font-heading font-bold text-ink">
+                        새 작품 만들기
+                    </DialogTitle>
+                </DialogHeader>
+
+                {/* 선택 카드 영역 */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-6">
+                    {/* 빈 문서로 시작 카드 */}
+                    <button
+                        onClick={() => {
+                            onCreateBlank();
+                            onOpenChange(false);
+                        }}
+                        disabled={isCreating}
+                        className={cn(
+                            "group relative flex flex-col items-center justify-center gap-4 p-8 rounded-xl",
+                            "border-2 border-dashed border-stone-200 hover:border-sage-400",
+                            "bg-white hover:bg-sage-50/50 transition-all duration-300",
+                            "focus:outline-none focus:ring-2 focus:ring-sage-400 focus:ring-offset-2",
+                            isCreating && "opacity-50 cursor-not-allowed"
+                        )}
+                    >
+                        {/* 아이콘 */}
+                        <div
+                            className={cn(
+                                "w-16 h-16 rounded-2xl flex items-center justify-center",
+                                "bg-stone-50 group-hover:bg-sage-100 transition-colors duration-300"
+                            )}
+                        >
+                            <FileText
+                                className={cn(
+                                    "w-8 h-8 text-stone-400",
+                                    "group-hover:text-sage-600 transition-colors duration-300"
+                                )}
+                            />
+                        </div>
+
+                        {/* 텍스트 */}
+                        <div className="text-center">
+                            <h3 className="text-lg font-semibold text-stone-900 group-hover:text-sage-700 transition-colors">
+                                {isCreating ? "생성 중..." : "빈 문서로 시작"}
+                            </h3>
+                            <p className="text-sm text-stone-500 mt-1">
+                                새로운 이야기를 시작하세요
+                            </p>
+                        </div>
+                    </button>
+
+                    {/* 기존 원고 불러오기 카드 */}
+                    <button
+                        onClick={() => {
+                            onImport();
+                            onOpenChange(false);
+                        }}
+                        disabled={isCreating}
+                        className={cn(
+                            "group relative flex flex-col items-center justify-center gap-4 p-8 rounded-xl",
+                            "border-2 border-dashed border-stone-200 hover:border-sage-400",
+                            "bg-white hover:bg-sage-50/50 transition-all duration-300",
+                            "focus:outline-none focus:ring-2 focus:ring-sage-400 focus:ring-offset-2",
+                            isCreating && "opacity-50 cursor-not-allowed"
+                        )}
+                    >
+                        {/* 아이콘 */}
+                        <div
+                            className={cn(
+                                "w-16 h-16 rounded-2xl flex items-center justify-center",
+                                "bg-stone-50 group-hover:bg-sage-100 transition-colors duration-300"
+                            )}
+                        >
+                            <Upload
+                                className={cn(
+                                    "w-8 h-8 text-stone-400",
+                                    "group-hover:text-sage-600 transition-colors duration-300"
+                                )}
+                            />
+                        </div>
+
+                        {/* 텍스트 */}
+                        <div className="text-center">
+                            <h3 className="text-lg font-semibold text-stone-900 group-hover:text-sage-700 transition-colors">
+                                기존 원고 불러오기
+                            </h3>
+                            <p className="text-sm text-stone-500 mt-1">
+                                TXT, MD 파일 지원
+                            </p>
+                        </div>
+                    </button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/library/StatusChip.tsx
+++ b/src/components/library/StatusChip.tsx
@@ -8,8 +8,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-// 프로젝트 상태 타입 정의
-export type ProjectStatusType = "writing" | "completed";
+// ✅ API 형식 통일 - 대문자만 사용
+export type ProjectStatusType = "EDITING" | "COMPLETED";
 
 interface StatusChipProps {
     // 현재 상태
@@ -22,14 +22,14 @@ interface StatusChipProps {
 
 // 상태별 라벨 정의
 const STATUS_LABELS: Record<ProjectStatusType, string> = {
-    writing: "Writing",
-    completed: "Complete",
+    EDITING: "Writing",
+    COMPLETED: "Complete",
 };
 
 /**
  * 상태 변경 드롭다운 칩 컴포넌트
  * - 클릭 시 드롭다운 메뉴 표시
- * - Writing/Complete 상태 선택 가능
+ * - Writing(EDITING)/Complete(COMPLETED) 상태 선택 가능
  * - Complete 상태 시 초록색 배경으로 시각적 피드백
  */
 export function StatusChip({
@@ -40,7 +40,7 @@ export function StatusChip({
     const [isOpen, setIsOpen] = useState(false);
 
     // 상태에 따른 스타일 결정
-    const isCompleted = status === "completed";
+    const isCompleted = status === "COMPLETED";
 
     return (
         <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -84,10 +84,10 @@ export function StatusChip({
                 className="min-w-[120px]"
                 onClick={(e) => e.stopPropagation()}
             >
-                {/* Writing 옵션 */}
+                {/* Writing(EDITING) 옵션 */}
                 <DropdownMenuItem
                     onClick={() => {
-                        onStatusChange("writing");
+                        onStatusChange("EDITING");
                         setIsOpen(false);
                     }}
                     className="flex items-center justify-between gap-2"
@@ -96,13 +96,13 @@ export function StatusChip({
                         <span className="h-2 w-2 rounded-full bg-sage-500" />
                         <span>Writing</span>
                     </div>
-                    {status === "writing" && <Check className="h-4 w-4 text-sage-600" />}
+                    {status === "EDITING" && <Check className="h-4 w-4 text-sage-600" />}
                 </DropdownMenuItem>
 
-                {/* Complete 옵션 */}
+                {/* Complete(COMPLETED) 옵션 */}
                 <DropdownMenuItem
                     onClick={() => {
-                        onStatusChange("completed");
+                        onStatusChange("COMPLETED");
                         setIsOpen(false);
                     }}
                     className="flex items-center justify-between gap-2"
@@ -111,7 +111,7 @@ export function StatusChip({
                         <span className="h-2 w-2 rounded-full bg-green-500" />
                         <span>Complete</span>
                     </div>
-                    {status === "completed" && (
+                    {status === "COMPLETED" && (
                         <Check className="h-4 w-4 text-green-600" />
                     )}
                 </DropdownMenuItem>

--- a/src/components/library/StatusChip.tsx
+++ b/src/components/library/StatusChip.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+// 프로젝트 상태 타입 정의
+export type ProjectStatusType = "writing" | "completed";
+
+interface StatusChipProps {
+    // 현재 상태
+    status: ProjectStatusType;
+    // 상태 변경 콜백
+    onStatusChange: (status: ProjectStatusType) => void;
+    // 비활성화 여부
+    disabled?: boolean;
+}
+
+// 상태별 라벨 정의
+const STATUS_LABELS: Record<ProjectStatusType, string> = {
+    writing: "Writing",
+    completed: "Complete",
+};
+
+/**
+ * 상태 변경 드롭다운 칩 컴포넌트
+ * - 클릭 시 드롭다운 메뉴 표시
+ * - Writing/Complete 상태 선택 가능
+ * - Complete 상태 시 초록색 배경으로 시각적 피드백
+ */
+export function StatusChip({
+    status,
+    onStatusChange,
+    disabled = false,
+}: StatusChipProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    // 상태에 따른 스타일 결정
+    const isCompleted = status === "completed";
+
+    return (
+        <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+            <DropdownMenuTrigger asChild disabled={disabled}>
+                <button
+                    onClick={(e) => e.stopPropagation()}
+                    className={cn(
+                        // 기본 스타일
+                        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold transition-all duration-200",
+                        // 호버 효과
+                        "hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-1",
+                        // 상태별 스타일
+                        isCompleted
+                            ? "bg-green-100 text-green-700 hover:bg-green-200 focus:ring-green-300"
+                            : "bg-sage-100 text-sage-700 hover:bg-sage-200 focus:ring-sage-300",
+                        // 비활성화 스타일
+                        disabled && "opacity-50 cursor-not-allowed"
+                    )}
+                >
+                    {/* 상태 인디케이터 도트 */}
+                    <span
+                        className={cn(
+                            "h-1.5 w-1.5 rounded-full",
+                            isCompleted ? "bg-green-500" : "bg-sage-500"
+                        )}
+                    />
+                    {/* 상태 라벨 */}
+                    <span>{STATUS_LABELS[status]}</span>
+                    {/* 드롭다운 화살표 */}
+                    <ChevronDown
+                        className={cn(
+                            "h-3 w-3 transition-transform duration-200",
+                            isOpen && "rotate-180"
+                        )}
+                    />
+                </button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent
+                align="start"
+                className="min-w-[120px]"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Writing 옵션 */}
+                <DropdownMenuItem
+                    onClick={() => {
+                        onStatusChange("writing");
+                        setIsOpen(false);
+                    }}
+                    className="flex items-center justify-between gap-2"
+                >
+                    <div className="flex items-center gap-2">
+                        <span className="h-2 w-2 rounded-full bg-sage-500" />
+                        <span>Writing</span>
+                    </div>
+                    {status === "writing" && <Check className="h-4 w-4 text-sage-600" />}
+                </DropdownMenuItem>
+
+                {/* Complete 옵션 */}
+                <DropdownMenuItem
+                    onClick={() => {
+                        onStatusChange("completed");
+                        setIsOpen(false);
+                    }}
+                    className="flex items-center justify-between gap-2"
+                >
+                    <div className="flex items-center gap-2">
+                        <span className="h-2 w-2 rounded-full bg-green-500" />
+                        <span>Complete</span>
+                    </div>
+                    {status === "completed" && (
+                        <Check className="h-4 w-4 text-green-600" />
+                    )}
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -85,13 +85,13 @@ export function useLogout() {
     onSuccess: () => {
       logout();
       queryClient.clear(); // Clear all cached data
-      navigate("/auth");
+      navigate("/");
     },
     onError: () => {
       // Even if API call fails, clear local auth state
       logout();
       queryClient.clear();
-      navigate("/auth");
+      navigate("/");
     },
   });
 }

--- a/src/hooks/useUpdateProjectStatus.ts
+++ b/src/hooks/useUpdateProjectStatus.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { projectService, type Project } from "@/services/projectService";
+import type { ProjectStatusType } from "@/components/library/StatusChip";
+import { projectKeys } from "./useProjects";
+
+/**
+ * 프로젝트 상태 업데이트를 위한 React Query Mutation Hook
+ * - 상태 변경 시 낙관적 업데이트 적용
+ * - 성공 시 자동으로 프로젝트 목록 리프레시
+ */
+export function useUpdateProjectStatus() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        // 상태 업데이트 요청
+        mutationFn: async ({
+            projectId,
+            status,
+        }: {
+            projectId: string;
+            status: ProjectStatusType;
+        }) => {
+            console.log("[useUpdateProjectStatus] Updating project:", projectId, "to status:", status);
+            return projectService.update(projectId, { status });
+        },
+
+        // 낙관적 업데이트: API 응답 전에 UI 먼저 업데이트
+        onMutate: async ({ projectId, status }) => {
+            console.log("[useUpdateProjectStatus] onMutate - projectId:", projectId);
+
+            // 진행 중인 리페치 취소 (모든 프로젝트 관련 쿼리)
+            await queryClient.cancelQueries({ queryKey: projectKeys.all });
+
+            // 이전 상태 스냅샷 - lists() 쿼리키 사용
+            const previousData = queryClient.getQueriesData({ queryKey: projectKeys.lists() });
+
+            // 낙관적으로 UI 업데이트 - 모든 리스트 쿼리에 대해 업데이트
+            queryClient.setQueriesData(
+                { queryKey: projectKeys.lists() },
+                (old: { projects?: Project[] } | undefined) => {
+                    if (!old?.projects) return old;
+                    console.log("[useUpdateProjectStatus] Updating cache for project:", projectId);
+                    return {
+                        ...old,
+                        projects: old.projects.map((p: Project) =>
+                            p.id === projectId ? { ...p, status } : p
+                        ),
+                    };
+                }
+            );
+
+            // 롤백용 컨텍스트 반환
+            return { previousData };
+        },
+
+        // 에러 시 롤백
+        onError: (error, _variables, context) => {
+            console.error("[useUpdateProjectStatus] Failed to update status:", error);
+            // 이전 데이터로 롤백
+            if (context?.previousData) {
+                context.previousData.forEach(([queryKey, data]) => {
+                    queryClient.setQueryData(queryKey, data);
+                });
+            }
+            alert("상태 변경에 실패했습니다.");
+        },
+
+        // 성공 시 로그
+        onSuccess: (data, variables) => {
+            console.log("[useUpdateProjectStatus] Success - projectId:", variables.projectId, "response:", data);
+        }
+    });
+}

--- a/src/pages/editor/components/EditorContent.tsx
+++ b/src/pages/editor/components/EditorContent.tsx
@@ -10,7 +10,7 @@ import EmptyState from "@/components/editor/EmptyState";
 import type { Document } from "@/types/document";
 
 interface EditorContentProps {
-  viewMode: "editor" | "scrivenings" | "outline";
+  viewMode: "editor" | "scrivenings" | "outline" | "corkboard";
   selectedFolderId: string | null;
   projectId: string;
   splitView: { enabled: boolean; direction: "horizontal" | "vertical" };

--- a/src/pages/editor/components/EditorToolbar.tsx
+++ b/src/pages/editor/components/EditorToolbar.tsx
@@ -32,8 +32,10 @@ interface EditorToolbarProps {
   characterCount: number;
 
   // View mode
-  viewMode: "editor" | "scrivenings" | "outline";
-  onViewModeChange: (mode: "editor" | "scrivenings" | "outline") => void;
+  viewMode: "editor" | "scrivenings" | "outline" | "corkboard";
+  onViewModeChange: (
+    mode: "editor" | "scrivenings" | "outline" | "corkboard"
+  ) => void;
 
   // Split view
   splitViewEnabled: boolean;
@@ -230,8 +232,10 @@ function TitleBreadcrumb({
 }
 
 interface ViewModeButtonsProps {
-  viewMode: "editor" | "scrivenings" | "outline";
-  onViewModeChange: (mode: "editor" | "scrivenings" | "outline") => void;
+  viewMode: "editor" | "scrivenings" | "outline" | "corkboard";
+  onViewModeChange: (
+    mode: "editor" | "scrivenings" | "outline" | "corkboard"
+  ) => void;
 }
 
 function ViewModeButtons({ viewMode, onViewModeChange }: ViewModeButtonsProps) {

--- a/src/pages/editor/hooks/useEditorHandlers.ts
+++ b/src/pages/editor/hooks/useEditorHandlers.ts
@@ -9,7 +9,7 @@ interface UseEditorHandlersOptions {
   selectedSectionId: string | null;
   setSelectedFolderId: (id: string | null) => void;
   setSelectedSectionId: (id: string | null) => void;
-  viewMode: "editor" | "scrivenings" | "outline";
+  viewMode: "editor" | "scrivenings" | "outline" | "corkboard";
   setViewMode: (mode: "editor" | "scrivenings" | "outline") => void;
   saveContent: (content: string) => Promise<void>;
   updateDocument: (updates: Partial<Document>) => void;
@@ -168,7 +168,7 @@ export function useEditorHandlers({
           clearTimeout(wordCountTimeoutRef.current);
         }
         wordCountTimeoutRef.current = setTimeout(() => {
-          updateDocumentRef.current({ metadata: { wordCount: count } });
+          updateDocumentRef.current({ metadata: { wordCount: count } as any });
         }, 1000);
       }
     },

--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -431,16 +431,11 @@ export default function LibraryPage() {
           <div className="flex flex-col gap-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <Link
-                  to="/"
-                  className="flex items-center hover:opacity-80 transition-opacity"
-                >
-                  <img
-                    src="/assets/main_logo.png"
-                    alt="Sto-Link"
-                    className="h-16 w-auto"
-                  />
-                </Link>
+                <img
+                  src="/assets/main_logo.png"
+                  alt="Sto-Link"
+                  className="h-16 w-auto"
+                />
               </div>
 
               <div className="flex items-center gap-3">


### PR DESCRIPTION
##  변경 사항

서재(Library) 페이지의 UX/UI를 3가지 주요 기능으로 개선했습니다:

### 1. 새 작품 생성 통합 모달
- CreateBookCard + ImportBookCard 제거
- 하단 플로팅 '새 작품 만들기' 버튼 추가
- CreateBookModal 컴포넌트: 빈 문서 생성 / 기존 원고 불러오기 선택

### 2. 상태 변경 드롭다운 칩
- StatusChip 컴포넌트: Writing  Complete 상태 변경
- 클릭 시 드롭다운 메뉴 표시
- Complete 상태 시 초록색 배경으로 시각적 피드백

### 3. 일괄 삭제 기능
- 헤더에 [편집] 버튼 추가
- 편집 모드에서 체크박스로 여러 책 선택
- 하단 플로팅 바에서 일괄 삭제

##  체크리스트
- [x] 빌드 성공 확인
- [x] 로컬 테스트 완료

##  Merge 가이드
- Target: develop
- Squash and Merge 권장