### PR TITLE
fix(workflow): start-work 상태변경 버그 수정 및 브랜치명 개선

### DIFF
--- a/.agent/workflows/start-work.md
+++ b/.agent/workflows/start-work.md
@@ -2,9 +2,19 @@
 description: 내게 할당된 이슈를 선택하여 작업 브랜치를 자동으로 생성하고 이동합니다.
 ---
 
-> **사용법:** `/start-work` (목록 보기) 또는 `/start-work <이슈번호>` (바로 시작)
+> **사용법:** `/start-work` (목록) 또는 `/start-work <이슈번호>` (작업 시작)
 
 // turbo-all
+
+---
+
+## 0. 브랜치명 생성 (AI 단계)
+
+이슈 번호가 주어지면, 스크립트를 실행하기 **전에**:
+
+1. `gh issue view <번호> --repo stolink/stolink-manage --json title -q .title` 로 제목 확인
+2. 한글 제목 → **영어 kebab-case** 변환 (예: "로그인 기능 추가" → "add-login")
+3. 변환된 이름을 **두 번째 인자**로 전달: `<번호> <영문이름>`
 
 ---
 
@@ -12,8 +22,10 @@ description: 내게 할당된 이슈를 선택하여 작업 브랜치를 자동�
 
 ```bash
 ISSUE_NUM=$1
+BRANCH_SUFFIX=$2
 MANAGEMENT_REPO="stolink/stolink-manage"
 PROJECT_NUMBER=1
+PROJECT_ID="PVT_kwDODvp_7s4BLZVL"
 STATUS_FIELD_ID="PVTSSF_lADODp_7s4BLZVLzg6-5Vg"
 IN_PROGRESS_OPTION_ID="47fc9ee4"
 
@@ -23,7 +35,7 @@ if [ -z "$ISSUE_NUM" ]; then
   gh project item-list $PROJECT_NUMBER --owner stolink --format json --limit 20 2>/dev/null | \
     jq -r '.items[] | select(.status == "Ready" or .status == "Open" or .status == null) | "  \(.content.number). \(.content.title)"'
   echo ""
-  echo "👉 /start-work <번호>"
+  echo "👉 /start-work <번호> [영문이름]"
   exit 0
 fi
 
@@ -40,15 +52,21 @@ if [ -z "$TITLE" ] || [ "$TITLE" == "null" ]; then
   exit 1
 fi
 
-# 브랜치 이름 생성
-SAFE_TITLE=$(echo "$TITLE" | sed -e 's/[^a-zA-Z0-9가-힣 ]//g' | tr ' ' '-')
+# 브랜치 prefix 결정 (bug 라벨이면 fix, 아니면 feature)
 IS_BUG=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' 2>/dev/null | grep -i "bug" || true)
 if [ -n "$IS_BUG" ]; then
   PREFIX="fix"
 else
   PREFIX="feature"
 fi
-BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_TITLE}"
+
+# 브랜치 이름: 영문 suffix가 있으면 사용, 없으면 번호만
+if [ -n "$BRANCH_SUFFIX" ]; then
+  SAFE_SUFFIX=$(echo "$BRANCH_SUFFIX" | sed -e 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]')
+  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_SUFFIX}"
+else
+  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}"
+fi
 
 # 브랜치 생성/이동 (즉시 실행)
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
@@ -65,7 +83,7 @@ echo "📝 $TITLE"
   gh issue edit "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --add-assignee "@me" >/dev/null 2>&1
   ITEM_ID=$(gh project item-list $PROJECT_NUMBER --owner stolink --format json 2>/dev/null | jq -r ".items[] | select(.content.number == $ISSUE_NUM) | .id")
   if [ -n "$ITEM_ID" ]; then
-    gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_NUMBER" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" >/dev/null 2>&1
+    gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" >/dev/null 2>&1
   fi
 ) &
 disown


### PR DESCRIPTION
## 📋 변경 사항

### start-work 워크플로우 개선

- **In Progress 상태 변경 버그 수정** - `--project-id`에 GraphQL Node ID 사용
- **한글→영어 브랜치명 자동 변환** - AI가 이슈 제목을 영어 kebab-case로 번역

## ✅ 체크리스트

- [x] 빌드 성공 확인
- [x] 타입 체크 통과

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장

Closes stolink/stolink-manage#7
