### PR TITLE
feat: Implement drag-and-drop section ordering and sidebar sync

### DIFF
--- a/.troubles/2025-12-27_SectionStrip-Drag-Accessiblity.md
+++ b/.troubles/2025-12-27_SectionStrip-Drag-Accessiblity.md
@@ -1,0 +1,62 @@
+# SectionStrip Drag Interaction & Accessibility Fixes
+
+## Issue Description
+
+### 1. 드래그 핸들 클릭 불가 (🔴 치명적)
+
+- **증상**: 사용자가 섹션 카드 내의 드래그 핸들(grip icon)을 클릭하거나 드래그하려고 해도 동작하지 않음.
+- **원인**: 카드 Header 영역에 `pointer-events-none` 클래스가 적용되어 있어, 자식 요소인 드래그 핸들의 이벤트까지 차단됨. 또한 클릭 오버레이(`z-0`)와 헤더(`z-10`)의 레이어 중첩 문제로 인해 이벤트 타겟팅이 모호함.
+- **파일**: `src/components/editor/SectionStrip.tsx`
+
+### 2. 접근성 미흡 (⚠️ 경고)
+
+- **증상**: 키보드 사용자가 카드를 선택했을 때(`Tab` 포커스), 현재 선택 여부를 스크린 리더가 알 수 없고, `onClick`만 있어 키보드 조작(`Enter`/`Space`)이 불가능함.
+- **원인**: `aria-pressed` 속성 누락 및 키보드 이벤트 핸들러 부재.
+
+### 3. 데이터 동기화 안정성 부족 (⚠️ 경고)
+
+- **증상**: 드래그 앤 드롭으로 순서를 바꾼 후, 간헐적으로 서버 데이터와 프론트엔드 데이터가 불일치할 가능성 존재.
+- **원인**: `reorderDocuments` 실행 후 `queryClient.invalidateQueries`를 호출하지 않아 React Query 캐시가 갱신되지 않음.
+- **파일**: `src/hooks/useDocuments.ts`
+
+## Solution Strategy
+
+### 1. 드래그 핸들 상호작용 개선
+
+- 드래그 핸들 `div`에 `pointer-events-auto` 클래스를 추가하여 부모의 `pointer-events-none`을 오버라이드.
+- 이를 통해 헤더 영역은 클릭을 통과시키지만(아래의 카드 선택 영역으로), 드래그 핸들은 직접 이벤트를 받아 드래그 동작이 가능해짐.
+
+### 2. 접근성 강화
+
+- 클릭 오버레이 `div`에 `aria-pressed={isSelected}` 속성 추가.
+- `onKeyDown` 핸들러를 추가하여 `Enter` 또는 `Space` 키 입력 시 `onClick`과 동일한 동작 수행.
+- 클릭 영역에 `cursor-pointer` 및 `role="button"` 명시.
+
+### 3. 데이터 동기화 로직 보완
+
+- `reorderDocuments` 함수 내에서 API 호출 성공 시 `queryClient.invalidateQueries({ queryKey: ["documents", projectId] })`를 호출하도록 수정.
+- 낙관적 업데이트 실패 시 롤백 로직 유지.
+
+### 변경 코드 (SectionStrip.tsx)
+
+```tsx
+// 변경 전 (드래그 핸들)
+<div
+  {...listeners}
+  className="p-1 -mr-2 cursor-grab active:cursor-grabbing hover:bg-stone-100 rounded-md transition-colors"
+>
+
+// 변경 후
+<div
+  {...listeners}
+  className="p-1 -mr-2 cursor-grab active:cursor-grabbing hover:bg-stone-100 rounded-md transition-colors pointer-events-auto"
+>
+```
+
+## Outcome
+
+- **상태**: ✅ 해결됨
+- **검증 방법**:
+  - **UI 테스트**: 드래그 핸들을 잡고 카드를 이동시켰을 때 정상적으로 드래그 시작 및 완료 확인. 카드 클릭 시 선택 동작 확인.
+  - **접근성 테스트**: 키보드 `Tab`으로 이동 후 `Enter` 키로 섹션 선택되는지 확인.
+  - **데이터 테스트**: 네트워크 탭에서 `reorder` API 호출 성공 후 즉시 `documents` 쿼리가 refetch 되는지 확인.

--- a/src/components/editor/SectionStrip.tsx
+++ b/src/components/editor/SectionStrip.tsx
@@ -287,14 +287,23 @@ function SectionCard({
       {/* Click handler separate from drag listeners logic if needed, but here wrapping div acts as drag handle */}
       {/* We apply onClick to a covering div or handle specific click logic */}
       <div
-        className="absolute inset-0 z-0"
-        onClick={onClick}
+        className="absolute inset-0 z-0 cursor-pointer"
+        onClick={(e) => {
+          if (!isDragging) onClick();
+          e.stopPropagation();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            onClick();
+            e.preventDefault();
+          }
+        }}
         role="button"
         tabIndex={0}
       />
 
       {/* Header: Index + Status */}
-      <div className="flex items-center justify-between mb-2 z-10 pointers-events-none">
+      <div className="flex items-center justify-between mb-2 z-10 pointer-events-none">
         <div className="flex items-center gap-2">
           <span
             className={cn(

--- a/src/components/editor/SectionStrip.tsx
+++ b/src/components/editor/SectionStrip.tsx
@@ -300,6 +300,7 @@ function SectionCard({
         }}
         role="button"
         tabIndex={0}
+        aria-pressed={isSelected}
       />
 
       {/* Header: Index + Status */}
@@ -320,10 +321,10 @@ function SectionCard({
             title={config.label}
           />
         </div>
-        {/* Drag Handle Icon - now we make the whole card draggable, but we can make just this handle draggable by moving listeners here */}
+        {/* Drag Handle Icon - needs pointer-events-auto to override parent's none */}
         <div
           {...listeners}
-          className="p-1 -mr-2 cursor-grab active:cursor-grabbing hover:bg-stone-100 rounded-md transition-colors"
+          className="p-1 -mr-2 cursor-grab active:cursor-grabbing hover:bg-stone-100 rounded-md transition-colors pointer-events-auto"
         >
           <GripVertical className="w-4 h-4 text-stone-300 group-hover:text-stone-400" />
         </div>


### PR DESCRIPTION
## 📋 변경 사항

- **왼쪽 사이드바 트리 정렬**: `buildTree` 함수를 수정하여 `order` 및 `createdAt` 기준으로 노드를 정렬합니다.
- **드래그 앤 드롭 동기화**: 섹션 스트립의 드래그 동작이 사이드바에 즉시 반영됩니다.
- **AI 리뷰 반영 (Fixes)**:
  - **접근성 개선**: 키보드 조작(`Enter`/ `Space`) 및 `aria-pressed` 속성 추가.
  - **드래그 핸들 수정**: `pointer-events-auto` 추가로 드래그 핸들 클릭 불가 문제 해결.
  - **데이터 정합성**: `reorderDocuments` 성공 시 `invalidateQueries` 호출.
- **성능 및 UX 개선**:
  - **Layering 최적화**: 클릭 영역, 드래그 핸들, 컨텐츠의 z-index 계층 분리로 오동작 방지.
  - **반응성 개선**: 드래그 중 `transition: undefined` 설정 및 시각적 피드백(Scale/Rotate/Shadow) 강화로 빠릿한 느낌 제공.

## 📁 변경된 파일

- `src/hooks/useDocuments.ts`: 정렬 로직 및 데이터 동기화 개선
- `src/components/editor/SectionStrip.tsx`: Card 구조 전면 리팩토링 및 스타일 개선
- `.troubles/2025-12-27_SectionStrip-Drag-Accessiblity.md`: 트러블슈팅 로그 추가

## ✅ 체크리스트

- [x] 빌드 성공 확인
- [x] 로컬 테스트 완료 (드래그 반응성, 클릭 분리, 데이터 동기화 확인)

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
