### PR TITLE
refactor: improve start-work workflow and documentation

### DIFF
--- a/.agent/workflows/start-work.md
+++ b/.agent/workflows/start-work.md
@@ -2,9 +2,19 @@
 description: 내게 할당된 이슈를 선택하여 작업 브랜치를 자동으로 생성하고 이동합니다.
 ---
 
-> **사용법:** `/start-work` (목록 보기) 또는 `/start-work <이슈번호>` (바로 시작)
+> **사용법:** `/start-work` (목록) 또는 `/start-work <이슈번호>` (작업 시작)
 
 // turbo-all
+
+---
+
+## 0. 브랜치명 생성 (AI 단계)
+
+이슈 번호가 주어지면, 스크립트를 실행하기 **전에**:
+
+1. `gh issue view <번호> --repo stolink/stolink-manage --json title -q .title` 로 제목 확인
+2. 한글 제목 → **영어 kebab-case** 변환 (예: "로그인 기능 추가" → "add-login")
+3. 변환된 이름을 **두 번째 인자**로 전달: `<번호> <영문이름>`
 
 ---
 
@@ -12,8 +22,10 @@ description: 내게 할당된 이슈를 선택하여 작업 브랜치를 자동�
 
 ```bash
 ISSUE_NUM=$1
+BRANCH_SUFFIX=$2
 MANAGEMENT_REPO="stolink/stolink-manage"
 PROJECT_NUMBER=1
+PROJECT_ID="PVT_kwDODvp_7s4BLZVL"
 STATUS_FIELD_ID="PVTSSF_lADODp_7s4BLZVLzg6-5Vg"
 IN_PROGRESS_OPTION_ID="47fc9ee4"
 
@@ -23,7 +35,7 @@ if [ -z "$ISSUE_NUM" ]; then
   gh project item-list $PROJECT_NUMBER --owner stolink --format json --limit 20 2>/dev/null | \
     jq -r '.items[] | select(.status == "Ready" or .status == "Open" or .status == null) | "  \(.content.number). \(.content.title)"'
   echo ""
-  echo "👉 /start-work <번호>"
+  echo "👉 /start-work <번호> [영문이름]"
   exit 0
 fi
 
@@ -40,15 +52,21 @@ if [ -z "$TITLE" ] || [ "$TITLE" == "null" ]; then
   exit 1
 fi
 
-# 브랜치 이름 생성
-SAFE_TITLE=$(echo "$TITLE" | sed -e 's/[^a-zA-Z0-9가-힣 ]//g' | tr ' ' '-')
+# 브랜치 prefix 결정 (bug 라벨이면 fix, 아니면 feature)
 IS_BUG=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' 2>/dev/null | grep -i "bug" || true)
 if [ -n "$IS_BUG" ]; then
   PREFIX="fix"
 else
   PREFIX="feature"
 fi
-BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_TITLE}"
+
+# 브랜치 이름: 영문 suffix가 있으면 사용, 없으면 번호만
+if [ -n "$BRANCH_SUFFIX" ]; then
+  SAFE_SUFFIX=$(echo "$BRANCH_SUFFIX" | sed -e 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]')
+  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_SUFFIX}"
+else
+  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}"
+fi
 
 # 브랜치 생성/이동 (즉시 실행)
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
@@ -65,7 +83,7 @@ echo "📝 $TITLE"
   gh issue edit "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --add-assignee "@me" >/dev/null 2>&1
   ITEM_ID=$(gh project item-list $PROJECT_NUMBER --owner stolink --format json 2>/dev/null | jq -r ".items[] | select(.content.number == $ISSUE_NUM) | .id")
   if [ -n "$ITEM_ID" ]; then
-    gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_NUMBER" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" >/dev/null 2>&1
+    gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" >/dev/null 2>&1
   fi
 ) &
 disown

--- a/.agent/workflows/start-work.md
+++ b/.agent/workflows/start-work.md
@@ -1,90 +1,20 @@
 ---
-description: 내게 할당된 이슈를 선택하여 작업 브랜치를 자동으로 생성하고 이동합니다.
+description: Start working on an issue by creating a branch and updating project status
 ---
 
-> **사용법:** `/start-work` (목록) 또는 `/start-work <이슈번호>` (작업 시작)
+# Start Work
 
-// turbo-all
+To start working on an issue, run the `start-work.sh` script.
 
----
+Usage: `./scripts/start-work.sh <ISSUE_NUM> [BRANCH_SUFFIX]`
 
-## 0. 브랜치명 생성 (AI 단계)
+Examples:
 
-이슈 번호가 주어지면, 스크립트를 실행하기 **전에**:
+- `./scripts/start-work.sh` (View available issues)
+- `./scripts/start-work.sh 123` (Start work on issue #123)
+- `./scripts/start-work.sh 123 fix-login-bug` (Start work on issue #123 with branch suffix)
 
-1. `gh issue view <번호> --repo stolink/stolink-manage --json title -q .title` 로 제목 확인
-2. 한글 제목 → **영어 kebab-case** 변환 (예: "로그인 기능 추가" → "add-login")
-3. 변환된 이름을 **두 번째 인자**로 전달: `<번호> <영문이름>`
+Steps:
 
----
-
-## 1. 작업 시작 스크립트 실행
-
-```bash
-ISSUE_NUM=$1
-BRANCH_SUFFIX=$2
-MANAGEMENT_REPO="stolink/stolink-manage"
-PROJECT_NUMBER=1
-PROJECT_ID="PVT_kwDODvp_7s4BLZVL"
-STATUS_FIELD_ID="PVTSSF_lADODp_7s4BLZVLzg6-5Vg"
-IN_PROGRESS_OPTION_ID="47fc9ee4"
-
-# 인자 없으면 목록 출력
-if [ -z "$ISSUE_NUM" ]; then
-  echo "📋 작업 가능한 이슈:"
-  gh project item-list $PROJECT_NUMBER --owner stolink --format json --limit 20 2>/dev/null | \
-    jq -r '.items[] | select(.status == "Ready" or .status == "Open" or .status == null) | "  \(.content.number). \(.content.title)"'
-  echo ""
-  echo "👉 /start-work <번호> [영문이름]"
-  exit 0
-fi
-
-# 이슈 정보 조회
-ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --json title,labels 2>/dev/null)
-if [ -z "$ISSUE_DATA" ]; then
-  echo "❌ 이슈 #$ISSUE_NUM 조회 실패"
-  exit 1
-fi
-
-TITLE=$(echo "$ISSUE_DATA" | jq -r .title)
-if [ -z "$TITLE" ] || [ "$TITLE" == "null" ]; then
-  echo "❌ 이슈 정보 없음"
-  exit 1
-fi
-
-# 브랜치 prefix 결정 (bug 라벨이면 fix, 아니면 feature)
-IS_BUG=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' 2>/dev/null | grep -i "bug" || true)
-if [ -n "$IS_BUG" ]; then
-  PREFIX="fix"
-else
-  PREFIX="feature"
-fi
-
-# 브랜치 이름: 영문 suffix가 있으면 사용, 없으면 번호만
-if [ -n "$BRANCH_SUFFIX" ]; then
-  SAFE_SUFFIX=$(echo "$BRANCH_SUFFIX" | sed -e 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]')
-  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_SUFFIX}"
-else
-  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}"
-fi
-
-# 브랜치 생성/이동 (즉시 실행)
-if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-  git checkout "$BRANCH_NAME" >/dev/null 2>&1
-  echo "✅ $BRANCH_NAME (기존)"
-else
-  git checkout -b "$BRANCH_NAME" >/dev/null 2>&1
-  echo "✅ $BRANCH_NAME (신규)"
-fi
-echo "📝 $TITLE"
-
-# 백그라운드: 작업자 할당 & 프로젝트 상태 변경
-(
-  gh issue edit "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --add-assignee "@me" >/dev/null 2>&1
-  ITEM_ID=$(gh project item-list $PROJECT_NUMBER --owner stolink --format json 2>/dev/null | jq -r ".items[] | select(.content.number == $ISSUE_NUM) | .id")
-  if [ -n "$ITEM_ID" ]; then
-    gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" >/dev/null 2>&1
-  fi
-) &
-disown
-```
+1. Run the script with the issue number.
+   `./scripts/start-work.sh <ISSUE_NUM> [BRANCH_SUFFIX]`

--- a/docs/workflow/WORKFLOW_STANDARD.md
+++ b/docs/workflow/WORKFLOW_STANDARD.md
@@ -51,6 +51,7 @@ graph LR
 2.  **프로젝트 추가**: 우측 사이드바 `Projects`에서 **`stolink board`** 선택.
 3.  **Status 설정**: 'Status'를 **`Ready`**로 설정.
     - (Option) 중요도, 사이즈 등을 입력.
+    - **⭐️ 중요: 이슈 제목은 "그래프 UI 개선"처럼 명확하고 간결한 '기능 단위'로 작성**해주세요. (브랜치 이름 생성 기준이 됩니다.)
     - _(참고)_ Draft Item으로 보드에서 먼저 만들고 나중에 'Convert to Issue' 해도 됩니다.
 
 ### Phase 2. 작업 가져오기 (Developer)
@@ -67,7 +68,9 @@ graph LR
     - 예: `/start-work 3`
 
 2.  **자동 수행되는 일**:
-    - 브랜치 생성 (`feature/123-title`) 및 이동.
+    - AI Agent가 이슈 내용을 파악하여 **적절하고 간결한 영문 브랜치명**을 생성합니다.
+      - 예: 이슈 "그래프 UI 개선" -> 브랜치 `feature/123-graph-ui`
+    - 브랜치 생성 및 이동.
     - 담당자(Assignees)에 **나(`@me`)** 할당 (백그라운드).
     - 프로젝트 상태 변경: `Ready` → **`In Progress`** (백그라운드).
 3.  작업 시작!

--- a/scripts/start-work.sh
+++ b/scripts/start-work.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+ISSUE_NUM=$1
+BRANCH_SUFFIX=$2
+MANAGEMENT_REPO="stolink/stolink-manage"
+PROJECT_NUMBER=1
+PROJECT_ID="PVT_kwDODvp_7s4BLZVL"
+STATUS_FIELD_ID="PVTSSF_lADODvp_7s4BLZVLzg6-5Vg"
+IN_PROGRESS_OPTION_ID="47fc9ee4"
+
+# PTY 에러 방지 - 핵심 설정
+
+export GH_FORCE_TTY=0
+export GH_NO_UPDATE_NOTIFIER=1
+export GH_PROMPT_DISABLED=1
+export NO_COLOR=1
+export TERM=dumb
+
+# 인자 없으면 목록 출력
+
+if [ -z "$ISSUE_NUM" ]; then
+echo "📋 작업 가능한 이슈:"
+ITEMS=$(gh project item-list $PROJECT_NUMBER --owner stolink --format json --limit 20 2>/dev/null || echo '{"items":[]}')
+  echo "$ITEMS" | jq -r '.items[] | select(.status == "Ready" or .status == "Open" or .status == null) | " \(.content.number). \(.content.title)"' 2>/dev/null
+echo ""
+echo "👉 /start-work <번호> [영문이름]"
+exit 0
+fi
+
+# 이슈 정보 조회
+
+ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --json title,labels 2>/dev/null)
+if [ -z "$ISSUE_DATA" ]; then
+echo "❌ 이슈 #$ISSUE_NUM 조회 실패"
+exit 1
+fi
+
+TITLE=$(echo "$ISSUE_DATA" | jq -r .title)
+if [ -z "$TITLE" ] || [ "$TITLE" == "null" ]; then
+echo "❌ 이슈 정보 없음"
+exit 1
+fi
+
+# 브랜치 prefix 결정
+
+IS_BUG=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name // empty' 2>/dev/null | grep -i "bug" || true)
+if [ -n "$IS_BUG" ]; then
+PREFIX="fix"
+else
+PREFIX="feature"
+fi
+
+# 브랜치 이름
+
+if [ -n "$BRANCH_SUFFIX" ]; then
+SAFE_SUFFIX=$(echo "$BRANCH_SUFFIX" | sed -e 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]')
+BRANCH_NAME="${PREFIX}/${ISSUE_NUM}-${SAFE_SUFFIX}"
+else
+  BRANCH_NAME="${PREFIX}/${ISSUE_NUM}"
+fi
+
+# 브랜치 생성/이동
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  git checkout "$BRANCH_NAME" >/dev/null 2>&1
+echo "✅ $BRANCH_NAME (기존)"
+else
+  git checkout -b "$BRANCH_NAME" >/dev/null 2>&1
+echo "✅ $BRANCH_NAME (신규)"
+fi
+echo "📝 $TITLE"
+
+# 백그라운드 작업 - 완전히 분리
+
+(
+export GH_FORCE_TTY=0
+export GH_NO_UPDATE_NOTIFIER=1
+export GH_PROMPT_DISABLED=1
+export NO_COLOR=1
+export TERM=dumb
+
+gh issue edit "$ISSUE_NUM" --repo "$MANAGEMENT_REPO" --add-assignee "@me" 2>/dev/null || true
+
+ITEM_ID=$(gh project item-list $PROJECT_NUMBER --owner stolink --format json 2>/dev/null | jq -r ".items[] | select(.content.number == $ISSUE_NUM) | .id" 2>/dev/null)
+  if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$IN_PROGRESS_OPTION_ID" 2>/dev/null || true
+fi
+) </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true


### PR DESCRIPTION
## 📋 변경 사항

- `start-work` 워크플로우를 개선하여 스크립트 기반으로 변경했습니다. (`scripts/start-work.sh`)
- `start-work` 명령어 실행 시 이슈 제목을 기반으로 간결한 영문 브랜치명을 자동 생성하도록 개선했습니다.
- `WORKFLOW_STANDARD.md` 문서를 업데이트하여 이슈 명명 규칙과 자동화된 브랜치 생성 로직을 반영했습니다.

## 📁 변경된 파일

- `.agent/workflows/start-work.md`
- `docs/workflow/WORKFLOW_STANDARD.md`
- `scripts/start-work.sh` (New)

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장

Closes stolink/stolink-manage#8
