### PR TITLE
fix: useSharedProject hook retry option support for build fix

### DIFF
--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -73,7 +73,13 @@ export function useDeleteShareLink() {
 export function useSharedProject(
   shareId: string,
   password?: string,
-  options?: { enabled?: boolean },
+  options?: {
+    enabled?: boolean;
+    retry?:
+      | boolean
+      | number
+      | ((failureCount: number, error: Error) => boolean);
+  },
 ) {
   return useQuery({
     queryKey: shareKeys.public(shareId, password),
@@ -82,6 +88,6 @@ export function useSharedProject(
       return response.data;
     },
     enabled: options?.enabled !== false && !!shareId,
-    retry: false,
+    retry: options?.retry ?? false,
   });
 }

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,13 +1,14 @@
 # Troubleshooting Log
 
-| Date       | Issue                        | Status      | Note                                                                                              |
-| ---------- | ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------- |
-| 2025-12-27 | AI Review Fixes (Hooks & UI) | ✅ Resolved | Fixed `useDuplicateProject` return value and `renameTarget` safety in LibraryPage                 |
-| 2025-12-28 | PR #52 AI Review Fixes       | ✅ Resolved | Added API response validation and optimized ESC key handler in WorldPage                          |
-| 2025-12-28 | PR #53 AI Review Fixes       | ✅ Resolved | Fixed projectId guard, extracted useRelationshipLinks, removed logs                               |
-| 2025-12-28 | PR #56 AI Review Fixes       | ✅ Resolved | Extracted `UseForceSimulationOptionsWithGrouping` interface; 3 critical issues already resolved   |
-| 2025-12-28 | PR #67 AI Review Fixes       | ✅ Resolved | Fixed critical type safety and runtime error issues in SharedProjectPage, and improved UX         |
-| 2025-12-28 | PR #67 AI Review Round 2     | ✅ Resolved | Addresses rigorous type safety in recursive traverse and fixes query enabled logic                |
-| 2025-12-28 | PR #67 AI Review Round 3     | ✅ Resolved | Addresses subtle query refetch issues, enhanced type guards, and clipboard error handling         |
-| 2025-12-28 | PR #67 AI Review Round 4     | ✅ Resolved | Fixed strict type safety (any), runtime array checks, and hooks rule violation in SettingsPage    |
-| 2025-12-28 | PR #67 AI Review Round 5     | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
+| Date       | Issue                         | Status      | Note                                                                                              |
+| ---------- | ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------- |
+| 2025-12-27 | AI Review Fixes (Hooks & UI)  | ✅ Resolved | Fixed `useDuplicateProject` return value and `renameTarget` safety in LibraryPage                 |
+| 2025-12-28 | PR #52 AI Review Fixes        | ✅ Resolved | Added API response validation and optimized ESC key handler in WorldPage                          |
+| 2025-12-28 | PR #53 AI Review Fixes        | ✅ Resolved | Fixed projectId guard, extracted useRelationshipLinks, removed logs                               |
+| 2025-12-28 | PR #56 AI Review Fixes        | ✅ Resolved | Extracted `UseForceSimulationOptionsWithGrouping` interface; 3 critical issues already resolved   |
+| 2025-12-28 | PR #67 AI Review Fixes        | ✅ Resolved | Fixed critical type safety and runtime error issues in SharedProjectPage, and improved UX         |
+| 2025-12-28 | PR #67 AI Review Round 2      | ✅ Resolved | Addresses rigorous type safety in recursive traverse and fixes query enabled logic                |
+| 2025-12-28 | PR #67 AI Review Round 3      | ✅ Resolved | Addresses subtle query refetch issues, enhanced type guards, and clipboard error handling         |
+| 2025-12-28 | PR #67 AI Review Round 4      | ✅ Resolved | Fixed strict type safety (any), runtime array checks, and hooks rule violation in SettingsPage    |
+| 2025-12-28 | PR #67 AI Review Round 5      | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
+| 2025-12-28 | Build Fix (SharedProjectPage) | ✅ Resolved | Updated `useSharedProject` hook signature to support `retry` option, fixing build failure         |


### PR DESCRIPTION
## 📋 변경 사항

- `useSharedProject` 훅의 `options` 매개변수에 `retry` 옵션을 추가하였습니다.
- `SharedProjectPage.tsx`에서 발생하는 빌드 오류(retry 옵션 관련)를 해결하였습니다.
- `troubleshooting.md`에 빌드 오류 수정 내역을 기록하였습니다.
- `useShare.ts`의 lint 에러(`no-explicit-any`)를 수정하였습니다.

## 📁 변경된 파일

- `src/hooks/useShare.ts`
- `troubleshooting.md`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료
- [x] Lint 및 Type Check 통과

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장


Closes stolink/stolink-manage#19
