### PR TITLE
fix: 공유 링크 기능 개선 및 AI 리뷰 반영 (Round 2)

### DIFF
--- a/.troubles/2025-12-28_PR69-AI-Review-Fixes.md
+++ b/.troubles/2025-12-28_PR69-AI-Review-Fixes.md
@@ -1,0 +1,63 @@
+# PR #69 AI Review 수정
+
+## Issue Description
+
+PR #69에서 AI 코드 리뷰가 2가지 이슈를 발견했습니다.
+
+### 🔴 치명적: 불안전한 타입 가드 (src/hooks/useShare.ts:29-31)
+
+- 에러: `error as { response?: { status?: number } }` 캐스팅으로 타입 검증 우회
+- 실제로 Axios 에러인지 보장되지 않음
+
+### ⚠️ 경고: 캐시 전략 불일치 (src/hooks/useShare.ts:75)
+
+- 에러: `setQueryData`로 즉시 null 설정 시, 삭제 실패해도 캐시가 null로 유지
+- 사용자는 성공한 것으로 오인
+
+## Solution Strategy
+
+### 변경 전 (타입 가드)
+
+```typescript
+if (error && typeof error === "object" && "response" in error) {
+  const axiosError = error as { response?: { status?: number } };
+  if (axiosError.response?.status === 404) {
+    return null;
+  }
+}
+```
+
+### 변경 후 (타입 가드)
+
+```typescript
+if (axios.isAxiosError(error) && error.response?.status === 404) {
+  return null;
+}
+```
+
+### 변경 전 (캐시 전략)
+
+```typescript
+onSuccess: (_data, projectId) => {
+  queryClient.setQueryData(shareKeys.settings(projectId), null);
+},
+```
+
+### 변경 후 (캐시 전략)
+
+```typescript
+onSuccess: (_data, projectId) => {
+  queryClient.setQueryData(shareKeys.settings(projectId), null);
+},
+onError: (_error, projectId) => {
+  queryClient.invalidateQueries({
+    queryKey: shareKeys.settings(projectId),
+  });
+},
+```
+
+## Outcome
+
+- **상태**: ✅ 해결됨
+- **빌드 결과**: `npm run build` 성공
+- **검증 방법**: TypeScript 컴파일 및 Vite 번들링 통과

--- a/.troubles/2025-12-28_PR69-AI-Review-Fixes.md
+++ b/.troubles/2025-12-28_PR69-AI-Review-Fixes.md
@@ -61,3 +61,87 @@ onError: (_error, projectId) => {
 - **상태**: ✅ 해결됨
 - **빌드 결과**: `npm run build` 성공
 - **검증 방법**: TypeScript 컴파일 및 Vite 번들링 통과
+
+---
+
+# PR #69 AI Review Round 2
+
+## Issue Description
+
+PR #69 AI 리뷰 2차에서 추가 이슈 발견:
+
+### ⚠️ 경고: axios 직접 import 사용 (src/hooks/useShare.ts:2)
+
+- 에러: `shareService`에서 이미 axios를 사용 중인데 hook에서도 직접 import하여 의존성 증가
+- 서비스 레이어 추상화가 깨짐
+
+### ⚠️ 경고: retry 설정과 404 처리 주석 개선 필요
+
+- 404를 '정상 상태'로 취급하므로 주석을 더 명확히 하거나 shareService로 이동 권장
+
+## Solution Strategy
+
+에러 처리 로직을 `shareService.getSettings()`로 이동하여 hook에서 axios import 제거.
+
+### 변경 전 (shareService.ts)
+
+```typescript
+getSettings: async (projectId: string) => {
+  const response = await api.get<ApiResponse<ShareSettings>>(
+    `/projects/${projectId}/share`
+  );
+  return response.data;
+},
+```
+
+### 변경 후 (shareService.ts)
+
+```typescript
+getSettings: async (projectId: string) => {
+  try {
+    const response = await api.get<ApiResponse<ShareSettings>>(
+      `/projects/${projectId}/share`
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return { data: null };
+    }
+    throw error;
+  }
+},
+```
+
+### 변경 전 (useShare.ts)
+
+```typescript
+import axios from "axios";
+// ...
+queryFn: async () => {
+  try {
+    const response = await shareService.getSettings(projectId);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+},
+```
+
+### 변경 후 (useShare.ts)
+
+```typescript
+// axios import 제거
+queryFn: async () => {
+  const response = await shareService.getSettings(projectId);
+  return response.data;
+},
+```
+
+## Outcome
+
+- **상태**: ✅ 해결됨
+- **빌드 결과**: `npm run build` 성공
+- **검증 방법**: TypeScript 컴파일 및 Vite 번들링 통과

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import axios from "axios";
 import { shareService } from "@/services/shareService";
 
 // Query Keys
@@ -13,8 +12,8 @@ export const shareKeys = {
 };
 
 /**
- * Hook for fetching share settings
- * Returns null if share is not enabled (404)
+ * Hook for fetching share settings.
+ * Returns null if sharing is not enabled (404 response handled in shareService).
  */
 export function useShareSettings(
   projectId: string,
@@ -23,19 +22,11 @@ export function useShareSettings(
   return useQuery({
     queryKey: shareKeys.settings(projectId),
     queryFn: async () => {
-      try {
-        const response = await shareService.getSettings(projectId);
-        return response.data;
-      } catch (error) {
-        // Axios 에러의 404 상태 코드 처리: 공유 링크 미존재 시 null 반환
-        if (axios.isAxiosError(error) && error.response?.status === 404) {
-          return null;
-        }
-        throw error;
-      }
+      const response = await shareService.getSettings(projectId);
+      return response.data;
     },
     enabled: options?.enabled !== false && !!projectId,
-    retry: false, // Don't retry if share is not enabled
+    retry: false, // 공유 미활성화는 재시도 불필요
   });
 }
 

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -73,7 +73,13 @@ export function useDeleteShareLink() {
 export function useSharedProject(
   shareId: string,
   password?: string,
-  options?: { enabled?: boolean },
+  options?: {
+    enabled?: boolean;
+    retry?:
+      | boolean
+      | number
+      | ((failureCount: number, error: Error) => boolean);
+  },
 ) {
   return useQuery({
     queryKey: shareKeys.public(shareId, password),
@@ -82,6 +88,6 @@ export function useSharedProject(
       return response.data;
     },
     enabled: options?.enabled !== false && !!shareId,
-    retry: false,
+    retry: options?.retry ?? false,
   });
 }

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
 import { shareService } from "@/services/shareService";
 
 // Query Keys
@@ -26,12 +27,9 @@ export function useShareSettings(
         const response = await shareService.getSettings(projectId);
         return response.data;
       } catch (error) {
-        // 404 means no share link exists - return null instead of throwing
-        if (error && typeof error === "object" && "response" in error) {
-          const axiosError = error as { response?: { status?: number } };
-          if (axiosError.response?.status === 404) {
-            return null;
-          }
+        // Axios 에러의 404 상태 코드 처리: 공유 링크 미존재 시 null 반환
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return null;
         }
         throw error;
       }
@@ -72,8 +70,14 @@ export function useDeleteShareLink() {
   return useMutation({
     mutationFn: (projectId: string) => shareService.disable(projectId),
     onSuccess: (_data, projectId) => {
-      // Immediately set cache to null for instant UI update
+      // 삭제 성공 시 즉시 캐시를 null로 설정하여 UI 즉시 갱신
       queryClient.setQueryData(shareKeys.settings(projectId), null);
+    },
+    onError: (_error, projectId) => {
+      // 삭제 실패 시 캐시 무효화로 다음 조회에서 리페치
+      queryClient.invalidateQueries({
+        queryKey: shareKeys.settings(projectId),
+      });
     },
   });
 }

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -13,6 +13,7 @@ export const shareKeys = {
 
 /**
  * Hook for fetching share settings
+ * Returns null if share is not enabled (404)
  */
 export function useShareSettings(
   projectId: string,
@@ -21,8 +22,19 @@ export function useShareSettings(
   return useQuery({
     queryKey: shareKeys.settings(projectId),
     queryFn: async () => {
-      const response = await shareService.getSettings(projectId);
-      return response.data;
+      try {
+        const response = await shareService.getSettings(projectId);
+        return response.data;
+      } catch (error) {
+        // 404 means no share link exists - return null instead of throwing
+        if (error && typeof error === "object" && "response" in error) {
+          const axiosError = error as { response?: { status?: number } };
+          if (axiosError.response?.status === 404) {
+            return null;
+          }
+        }
+        throw error;
+      }
     },
     enabled: options?.enabled !== false && !!projectId,
     retry: false, // Don't retry if share is not enabled
@@ -60,9 +72,8 @@ export function useDeleteShareLink() {
   return useMutation({
     mutationFn: (projectId: string) => shareService.disable(projectId),
     onSuccess: (_data, projectId) => {
-      queryClient.invalidateQueries({
-        queryKey: shareKeys.settings(projectId),
-      });
+      // Immediately set cache to null for instant UI update
+      queryClient.setQueryData(shareKeys.settings(projectId), null);
     },
   });
 }

--- a/src/services/shareService.ts
+++ b/src/services/shareService.ts
@@ -1,4 +1,5 @@
 import api from "@/api/client";
+import axios from "axios";
 import type { ApiResponse } from "@/types/api";
 
 export interface ShareSettings {
@@ -18,25 +19,37 @@ export interface SharedProject {
 export const shareService = {
   create: async (
     projectId: string,
-    options?: { expiresIn?: string; password?: string }
+    options?: { expiresIn?: string; password?: string },
   ) => {
     const response = await api.post<ApiResponse<ShareSettings>>(
       `/projects/${projectId}/share`,
-      options
+      options,
     );
     return response.data;
   },
 
+  /**
+   * Get share settings for a project.
+   * Returns null if sharing is not enabled (404 response).
+   */
   getSettings: async (projectId: string) => {
-    const response = await api.get<ApiResponse<ShareSettings>>(
-      `/projects/${projectId}/share`
-    );
-    return response.data;
+    try {
+      const response = await api.get<ApiResponse<ShareSettings>>(
+        `/projects/${projectId}/share`,
+      );
+      return response.data;
+    } catch (error) {
+      // 404 means sharing is not enabled - return null data
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return { data: null };
+      }
+      throw error;
+    }
   },
 
   disable: async (projectId: string) => {
     const response = await api.delete<ApiResponse<null>>(
-      `/projects/${projectId}/share`
+      `/projects/${projectId}/share`,
     );
     return response.data;
   },
@@ -47,7 +60,7 @@ export const shareService = {
       `/share/${shareId}`,
       {
         params: password ? { password } : undefined,
-      }
+      },
     );
     return response.data;
   },

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -13,3 +13,4 @@
 | 2025-12-28 | PR #67 AI Review Round 5      | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
 | 2025-12-28 | Build Fix (SharedProjectPage) | ✅ Resolved | Updated `useSharedProject` hook signature to support `retry` option, fixing build failure         |
 | 2025-12-28 | PR #69 AI Review Fixes        | ✅ Resolved | Used `axios.isAxiosError` for type-safe 404 handling, added `onError` handler for cache strategy  |
+| 2025-12-28 | PR #69 AI Review Round 2      | ✅ Resolved | Moved 404 error handling to `shareService` layer, removed axios import from hook                  |

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,13 +1,14 @@
 # Troubleshooting Log
 
-| Date       | Issue                        | Status      | Note                                                                                              |
-| ---------- | ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------- |
-| 2025-12-27 | AI Review Fixes (Hooks & UI) | ✅ Resolved | Fixed `useDuplicateProject` return value and `renameTarget` safety in LibraryPage                 |
-| 2025-12-28 | PR #52 AI Review Fixes       | ✅ Resolved | Added API response validation and optimized ESC key handler in WorldPage                          |
-| 2025-12-28 | PR #53 AI Review Fixes       | ✅ Resolved | Fixed projectId guard, extracted useRelationshipLinks, removed logs                               |
-| 2025-12-28 | PR #56 AI Review Fixes       | ✅ Resolved | Extracted `UseForceSimulationOptionsWithGrouping` interface; 3 critical issues already resolved   |
-| 2025-12-28 | PR #67 AI Review Fixes       | ✅ Resolved | Fixed critical type safety and runtime error issues in SharedProjectPage, and improved UX         |
-| 2025-12-28 | PR #67 AI Review Round 2     | ✅ Resolved | Addresses rigorous type safety in recursive traverse and fixes query enabled logic                |
-| 2025-12-28 | PR #67 AI Review Round 3     | ✅ Resolved | Addresses subtle query refetch issues, enhanced type guards, and clipboard error handling         |
-| 2025-12-28 | PR #67 AI Review Round 4     | ✅ Resolved | Fixed strict type safety (any), runtime array checks, and hooks rule violation in SettingsPage    |
-| 2025-12-28 | PR #67 AI Review Round 5     | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
+| Date       | Issue                         | Status      | Note                                                                                              |
+| ---------- | ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------- |
+| 2025-12-27 | AI Review Fixes (Hooks & UI)  | ✅ Resolved | Fixed `useDuplicateProject` return value and `renameTarget` safety in LibraryPage                 |
+| 2025-12-28 | PR #52 AI Review Fixes        | ✅ Resolved | Added API response validation and optimized ESC key handler in WorldPage                          |
+| 2025-12-28 | PR #53 AI Review Fixes        | ✅ Resolved | Fixed projectId guard, extracted useRelationshipLinks, removed logs                               |
+| 2025-12-28 | PR #56 AI Review Fixes        | ✅ Resolved | Extracted `UseForceSimulationOptionsWithGrouping` interface; 3 critical issues already resolved   |
+| 2025-12-28 | PR #67 AI Review Fixes        | ✅ Resolved | Fixed critical type safety and runtime error issues in SharedProjectPage, and improved UX         |
+| 2025-12-28 | PR #67 AI Review Round 2      | ✅ Resolved | Addresses rigorous type safety in recursive traverse and fixes query enabled logic                |
+| 2025-12-28 | PR #67 AI Review Round 3      | ✅ Resolved | Addresses subtle query refetch issues, enhanced type guards, and clipboard error handling         |
+| 2025-12-28 | PR #67 AI Review Round 4      | ✅ Resolved | Fixed strict type safety (any), runtime array checks, and hooks rule violation in SettingsPage    |
+| 2025-12-28 | PR #67 AI Review Round 5      | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
+| 2025-12-28 | Build Fix (SharedProjectPage) | ✅ Resolved | Updated `useSharedProject` hook signature to support `retry` option, fixing build failure         |

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -12,3 +12,4 @@
 | 2025-12-28 | PR #67 AI Review Round 4      | ✅ Resolved | Fixed strict type safety (any), runtime array checks, and hooks rule violation in SettingsPage    |
 | 2025-12-28 | PR #67 AI Review Round 5      | ✅ Resolved | Implemented `isPasswordSubmitted` state pattern, strict `useParams`, and `AlertDialog` for delete |
 | 2025-12-28 | Build Fix (SharedProjectPage) | ✅ Resolved | Updated `useSharedProject` hook signature to support `retry` option, fixing build failure         |
+| 2025-12-28 | PR #69 AI Review Fixes        | ✅ Resolved | Used `axios.isAxiosError` for type-safe 404 handling, added `onError` handler for cache strategy  |


### PR DESCRIPTION
## 📋 변경 사항

- 404 에러 처리를 `shareService.getSettings()` 레이어로 이동
- `useShare.ts`에서 axios import 제거 (서비스 레이어 추상화 유지)
- `useDeleteShareLink`에 `onSuccess`/`onError` 핸들러 추가
- `useSharedProject` 훅에 `retry` 옵션 지원 추가

## 📁 변경된 파일

- `src/hooks/useShare.ts` - axios import 제거, 간소화
- `src/services/shareService.ts` - 404 에러 처리 추가
- `troubleshooting.md` - 이슈 트래킹 업데이트
- `.troubles/2025-12-28_PR69-AI-Review-Fixes.md` - 상세 문서

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료
- [x] Lint 및 Type Check 통과
- [x] AI 코드 리뷰 Round 1 반영
- [x] AI 코드 리뷰 Round 2 반영

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장

Closes stolink/stolink-manage#19
