### PR TITLE
style: SVG 종이 질감 및 노이즈 효과 제거

### DIFF
--- a/src/components/effects/PaperTexture.tsx
+++ b/src/components/effects/PaperTexture.tsx
@@ -1,11 +1,9 @@
 /**
- * PaperTexture
+ * PaperTexture (Disabled)
  *
- * 버전 4: SVG 프로시저럴 노이즈 기반 종이 질감
- * 이미지 없이 무한 확장 가능한 순수 SVG 텍스처입니다.
+ * 종이 질감 효과가 제거되었습니다.
+ * 인터페이스 호환성을 위해 유지됩니다.
  */
-
-import { cn } from "@/lib/utils";
 
 interface PaperTextureProps {
   /** 불투명도 (0-1) */
@@ -16,52 +14,8 @@ interface PaperTextureProps {
   intensity?: number;
 }
 
-export function PaperTexture({
-  opacity = 0.08,
-  className,
-  intensity = 0.04,
-}: PaperTextureProps) {
-  const svgId = `paper-noise-${Math.random().toString(36).slice(2, 9)}`;
-
-  return (
-    <div
-      className={cn("absolute inset-0 pointer-events-none z-0", className)}
-      aria-hidden="true"
-    >
-      <svg
-        className="absolute inset-0 w-full h-full"
-        xmlns="http://www.w3.org/2000/svg"
-        preserveAspectRatio="none"
-      >
-        <defs>
-          <filter id={svgId} x="0%" y="0%" width="100%" height="100%">
-            <feTurbulence
-              type="fractalNoise"
-              baseFrequency={intensity}
-              numOctaves={5}
-              stitchTiles="stitch"
-              result="noise"
-            />
-            <feColorMatrix
-              type="saturate"
-              values="0"
-              in="noise"
-              result="mono"
-            />
-            <feComponentTransfer in="mono" result="final">
-              <feFuncA type="linear" slope={opacity * 3} intercept={0} />
-            </feComponentTransfer>
-          </filter>
-        </defs>
-        <rect
-          width="100%"
-          height="100%"
-          filter={`url(#${svgId})`}
-          style={{ mixBlendMode: "multiply" }}
-        />
-      </svg>
-    </div>
-  );
+export function PaperTexture(_props: PaperTextureProps) {
+  return null;
 }
 
 export default PaperTexture;

--- a/src/index.css
+++ b/src/index.css
@@ -186,19 +186,6 @@
     font-family: "DM Serif Display", "Pretendard", serif;
   }
 }
-
-.noise-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  pointer-events: none;
-  z-index: 40;
-  opacity: 0.04;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='1'/%3E%3C/svg%3E");
-}
-
 /* Focus Mode Sidebar - Hide drag handles and action buttons for cleaner look */
 .focus-mode-sidebar [data-tree-item] .cursor-grab,
 .focus-mode-sidebar [data-tree-item] button:not([data-toggle-expand]) {
@@ -208,38 +195,6 @@
 .focus-mode-sidebar [data-tree-item]:hover .cursor-grab,
 .focus-mode-sidebar [data-tree-item]:hover button:not([data-toggle-expand]) {
   display: none !important;
-}
-
-/* ============================================
-   Paper Texture Effects (Version 4)
-   ============================================ */
-
-/* Paper texture overlay - subtle grain effect */
-.paper-texture-overlay {
-  position: relative;
-}
-
-.paper-texture-overlay::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.025;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='paper'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.04' numOctaves='5' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23paper)'/%3E%3C/svg%3E");
-  mix-blend-mode: multiply;
-  z-index: 1;
-}
-
-/* Light version for headers/nav */
-.paper-texture-light::before {
-  opacity: 0.015;
-}
-
-/* Dark mode - reduce paper texture intensity by 50% */
-.theme-dark .paper-texture-overlay::before,
-.theme-true-black .paper-texture-overlay::before,
-.dark .paper-texture-overlay::before {
-  opacity: 0.0125;
 }
 
 /* Brush stroke underline effect - pure SVG */


### PR DESCRIPTION
## 📋 변경 사항

### 스타일 및 성능 최적화

- **SVG 필터 제거**: 성능 부하를 줄이기 위해 `PaperTexture` 및 `NoiseOverlay` SVG 필터 효과를 제거했습니다.
- **UI 정리**: 종이 질감 오버레이 제거로 더 깔끔한 UI를 제공합니다.

## 📁 변경된 파일

- `src/index.css`: `.noise-overlay`, `.paper-texture-overlay` 스타일 제거.
- `src/components/effects/PaperTexture.tsx`: 컴포넌트 비활성화 (`return null`).

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
