### PR TITLE
fix(graph): resolve visual issues and remove legacy types

### DIFF
--- a/src/components/CharacterGraph/LinkRenderer.tsx
+++ b/src/components/CharacterGraph/LinkRenderer.tsx
@@ -48,17 +48,17 @@ export const LinkRenderer = memo(function LinkRenderer({
   const color = RELATION_COLORS[link.type] || "#9ca3af";
 
   // 강도에 따른 선 두께
-  const baseWidth = 1 + (link.strength / 10) * 2;
+  const baseWidth = 1 + (link.strength / 10) * 4;
   const strokeWidth = isHighlighted ? baseWidth + 1.5 : baseWidth;
 
-  // 강도에 따른 기본 투명도
-  const baseOpacity = 0.3 + (link.strength / 10) * 0.4;
+  // 강도에 따른 기본 투명도 (가독성 위해 최소값 상향)
+  const baseOpacity = 0.6 + (link.strength / 10) * 0.4;
 
   // 투명도 계산 (가독성 개선)
   const getOpacity = () => {
-    if (isFiltered) return 0.03;
+    if (isFiltered) return 0.05;
     if (isDimmed) return ANIMATION.dimOpacity * 0.5;
-    if (isHighlighted) return 0.9;
+    if (isHighlighted) return 0.95;
     return baseOpacity;
   };
   const finalOpacity = getOpacity();
@@ -92,7 +92,7 @@ export const LinkRenderer = memo(function LinkRenderer({
         strokeWidth={strokeWidth}
         strokeOpacity={finalOpacity}
         strokeLinecap="round"
-        strokeDasharray={link.type === "enemy" ? "6,4" : undefined}
+        strokeDasharray={link.type === "hostile" ? "6,4" : undefined}
         style={{
           transition: `
             stroke-opacity ${ANIMATION.highlightDuration}ms ease,

--- a/src/components/CharacterGraph/NodeRenderer.tsx
+++ b/src/components/CharacterGraph/NodeRenderer.tsx
@@ -169,10 +169,7 @@ export const NodeRenderer = memo(function NodeRenderer({
             clipPath={`url(#clip-${node.id})`}
             preserveAspectRatio="xMidYMid slice"
             style={{
-              filter:
-                isDimmed || (!isHighlighted && !isSelected)
-                  ? "grayscale(80%) brightness(0.9)"
-                  : "none",
+              filter: isDimmed ? "grayscale(80%) brightness(0.9)" : "none",
               transition: `filter ${ANIMATION.highlightDuration}ms ease`,
             }}
           />

--- a/src/components/CharacterGraph/constants.ts
+++ b/src/components/CharacterGraph/constants.ts
@@ -4,18 +4,18 @@ import type { RelationType, CharacterRole } from "@/types";
 // 🎨 색상 설정
 // =====================================================
 
-// 관계 타입별 색상 (서사적 깊이, 형광 톤 제거)
+// 관계 타입별 색상 (서사적 깊이)
 export const RELATION_COLORS: Record<RelationType, string> = {
-  friend: "#4B9F7D", // Emerald - 신뢰감, 차분한 녹색
-  lover: "#C4718A", // Muted Rose - 성숙한 로맨스
-  enemy: "#B14B4B", // Russet Red - 위기감, 톤 다운된 레드
+  friendly: "#15803D", // Green 700 (Deep Green)
+  hostile: "#B91C1C", // Red 700 (Deep Red)
+  romantic: "#BE185D", // Pink 700 (Deep Pink)
 };
 
 // 관계 타입별 라벨 (한글)
 export const RELATION_LABELS: Record<RelationType, string> = {
-  friend: "친구",
-  lover: "연인",
-  enemy: "적대",
+  friendly: "우호",
+  hostile: "적대",
+  romantic: "로맨스",
 };
 
 // 역할별 라벨

--- a/src/components/CharacterGraph/index.tsx
+++ b/src/components/CharacterGraph/index.tsx
@@ -494,7 +494,7 @@ export const CharacterGraph = forwardRef<
           </g>
         </svg>
 
-        <div className="absolute top-4 right-4 bg-white/90 p-2 rounded shadow-sm border text-sm flex items-center gap-2">
+        <div className="absolute top-4 right-4 bg-white/90 p-2 rounded shadow-sm border text-sm flex items-center gap-2 z-20">
           <input
             type="checkbox"
             id="grouping-toggle"

--- a/src/pages/world/components/NetworkControlsD3.tsx
+++ b/src/pages/world/components/NetworkControlsD3.tsx
@@ -25,7 +25,7 @@ export function NetworkControlsD3({
   return (
     <>
       {/* 좌측 컨트롤 패널 */}
-      <div className="absolute left-4 top-4 z-10 bg-white rounded-lg border shadow-sm p-3 space-y-3">
+      <div className="absolute left-4 top-4 z-20 bg-white rounded-lg border shadow-sm p-3 space-y-3">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Controls
         </div>
@@ -48,47 +48,47 @@ export function NetworkControlsD3({
               <DropdownMenuRadioItem value="all">
                 모든 관계
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="friend">
-                친구 (초록)
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="lover">
-                연인 (핑크)
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="enemy">
-                적대 (빨강)
-              </DropdownMenuRadioItem>
+              {(Object.keys(RELATION_LABELS) as RelationType[]).map((type) => (
+                <DropdownMenuRadioItem
+                  key={type}
+                  value={type}
+                  className="cursor-pointer"
+                >
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{ backgroundColor: RELATION_COLORS[type] }}
+                    />
+                    {RELATION_LABELS[type]}
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
             </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
 
       {/* 하단 범례 */}
-      <div className="absolute left-4 bottom-4 z-10 bg-white rounded-lg border shadow-sm p-3">
+      <div className="absolute left-4 bottom-4 z-20 bg-white rounded-lg border shadow-sm p-3">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
           Relationship Legend
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
-          <div className="flex items-center gap-2">
-            <div
-              className="w-6 h-0.5"
-              style={{ backgroundColor: RELATION_COLORS.friend }}
-            />
-            <span>{RELATION_LABELS.friend}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div
-              className="w-6 h-0.5"
-              style={{ backgroundColor: RELATION_COLORS.lover }}
-            />
-            <span>{RELATION_LABELS.lover}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div
-              className="w-6 h-0.5 border-t-2 border-dashed"
-              style={{ borderColor: RELATION_COLORS.enemy }}
-            />
-            <span>{RELATION_LABELS.enemy}</span>
-          </div>
+          {(Object.keys(RELATION_LABELS) as RelationType[]).map((type) => (
+            <div key={type} className="flex items-center gap-2">
+              <div
+                className="w-6 h-0.5"
+                style={{
+                  backgroundColor: RELATION_COLORS[type],
+                  borderTop: undefined,
+                  borderStyle: type === "hostile" ? "dashed" : "solid", // 적대는 점선
+                  borderWidth: type === "hostile" ? "0 0 2px 0" : "0",
+                  height: type === "hostile" ? "0" : "2px",
+                }}
+              />
+              <span>{RELATION_LABELS[type]}</span>
+            </div>
+          ))}
         </div>
       </div>
     </>

--- a/src/pages/world/constants.ts
+++ b/src/pages/world/constants.ts
@@ -1,26 +1,17 @@
 import type { CharacterRole } from "@/types";
 
-export type RelationType =
-  | "friendship"
-  | "conflict"
-  | "romance"
-  | "family"
-  | "neutral";
+export type RelationType = "friendly" | "hostile" | "romantic";
 
 export const relationshipColors: Record<RelationType, string> = {
-  friendship: "#22c55e", // 초록
-  conflict: "#ef4444", // 빨강
-  romance: "#ec4899", // 핑크
-  family: "#1f2937", // 검정
-  neutral: "#9ca3af", // 회색 (점선용)
+  friendly: "#15803D", // Green 700 (Deep Green)
+  hostile: "#B91C1C", // Red 700 (Deep Red)
+  romantic: "#BE185D", // Pink 700 (Deep Pink)
 };
 
 export const relationshipLabels: Record<RelationType, string> = {
-  friendship: "우정",
-  conflict: "갈등",
-  romance: "로맨스",
-  family: "가족",
-  neutral: "중립",
+  friendly: "우호",
+  hostile: "적대",
+  romantic: "로맨스",
 };
 
 export const roleLabels: Record<CharacterRole, string> = {

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -1,12 +1,7 @@
 // Character Types with flexible extras pattern
 
 // 백엔드 RelationshipType 정의 (5종 - 백엔드 스펙)
-export type BackendRelationshipType =
-  | "friendly"
-  | "hostile"
-  | "neutral"
-  | "romantic"
-  | "family";
+export type BackendRelationshipType = "friendly" | "hostile" | "romantic";
 
 // 백엔드에서 반환하는 관계 구조 (Neo4j)
 export interface BackendRelationship {

--- a/src/types/characterGraph.ts
+++ b/src/types/characterGraph.ts
@@ -6,7 +6,8 @@ import type { CharacterRole } from "./character";
 // =====================================================
 
 // 관계 타입 (단순화: 3종)
-export type RelationType = "friend" | "lover" | "enemy";
+// 관계 타입 (BackendRelationshipType과 일치)
+export type RelationType = "friendly" | "hostile" | "romantic";
 
 // D3 시뮬레이션용 노드 타입
 export interface CharacterNode extends d3.SimulationNodeDatum {

--- a/src/utils/relationshipMapper.ts
+++ b/src/utils/relationshipMapper.ts
@@ -1,25 +1,34 @@
-import type { Character, BackendRelationshipType } from "@/types/character";
+import type { Character } from "@/types/character";
 import type { RelationType, RelationshipLink } from "@/types/characterGraph";
 
 /**
- * 백엔드 RelationshipType → D3 그래프 RelationType 변환
- *
- * @param backendType - 백엔드에서 사용하는 관계 타입 (5종)
- * @returns D3 그래프에서 사용하는 관계 타입 (3종: friend/lover/enemy)
+ * 관계 타입 정규화 (백엔드 데이터 불일치 대응)
+ * legacy: friendship, conflict, family, neutral (removed)
+ * new: friendly, hostile, romantic
  */
-export function toGraphRelationType(
-  backendType: BackendRelationshipType | string
-): RelationType {
-  const mapping: Record<string, RelationType> = {
-    friendly: "friend",
-    romantic: "lover",
-    hostile: "enemy",
-    family: "friend", // 가족 → 친구 관계로 표시
-    neutral: "friend", // 중립 → 친구 관계로 표시
-  };
-  return mapping[backendType] || "friend"; // Fallback for unexpected types
-}
+export function normalizeRelationType(type: string): RelationType {
+  const normalized = type.toLowerCase();
 
+  const mapping: Record<string, RelationType> = {
+    // Standard
+    friendly: "friendly",
+    hostile: "hostile",
+    romantic: "romantic",
+
+    // Legacy / Aliases / Mapping for removed types
+    family: "friendly", // 가족 -> 우호로 편입
+    neutral: "friendly", // 중립 -> 우호로 편입
+
+    friendship: "friendly",
+    friend: "friendly",
+    conflict: "hostile",
+    enemy: "hostile",
+    lover: "romantic",
+    romance: "romantic",
+  };
+
+  return mapping[normalized] || "friendly";
+}
 /**
  * Character.relationships를 D3 그래프용 Link 배열로 변환
  *
@@ -32,7 +41,7 @@ export function toGraphRelationType(
  * <CharacterGraph characters={characters} links={links} />
  */
 export function extractRelationshipLinks(
-  characters: Character[]
+  characters: Character[],
 ): RelationshipLink[] {
   const links: RelationshipLink[] = [];
   const processedPairs = new Set<string>();
@@ -41,7 +50,7 @@ export function extractRelationshipLinks(
     // 타입 가드: relationships가 배열인지 확인
     if (!Array.isArray(char.relationships)) {
       console.warn(
-        `Character ${char.id} (${char.name}) missing relationships array`
+        `Character ${char.id} (${char.name}) missing relationships array`,
       );
       return;
     }
@@ -53,7 +62,7 @@ export function extractRelationshipLinks(
       // target ID 검증
       if (!targetId) {
         console.warn(
-          `Invalid relationship for character ${char.id}: missing target`
+          `Invalid relationship for character ${char.id}: missing target`,
         );
         return;
       }
@@ -71,7 +80,7 @@ export function extractRelationshipLinks(
         id: String(rel.id),
         source: sourceId,
         target: targetId,
-        type: toGraphRelationType(rel.type),
+        type: normalizeRelationType(rel.type),
         strength: rel.strength,
         label: rel.label ?? undefined,
       });


### PR DESCRIPTION
## 📋 변경 사항
- **그래프 시각적 개선**: 관계선 색상을 선명한 Deep 톤으로 변경하고 투명도를 높여 가독성 개선
- **레거시 타입 제거**: `family`, `neutral` 타입 제거 및 `friendly`, `hostile`, `romantic` 3종으로 통합
- **UI 수정**: 필터 및 그룹 토글 버튼의 클릭 불가(z-index) 문제 해결

## ✅ 체크리스트
- [x] 빌드 및 로컬 테스트 완료

Closes stolink/stolink-manage#60
