### PR TITLE
refactor(sidebar): part 타입 제거 및 인라인 생성 UX 개선

### DIFF
--- a/src/components/editor/sidebar/ChapterTree.tsx
+++ b/src/components/editor/sidebar/ChapterTree.tsx
@@ -32,7 +32,7 @@ import { type ChapterNode, type ChapterTreeProps } from "./types";
 // Helper: 전체 트리에서 노드 찾기
 function findNodeById(
   nodes: ChapterNode[],
-  id: string
+  id: string,
 ): ChapterNode | undefined {
   for (const node of nodes) {
     if (node.id === id) return node;
@@ -48,7 +48,7 @@ function findNodeById(
 function findParentId(
   nodes: ChapterNode[],
   id: string,
-  parentId: string | null = null
+  parentId: string | null = null,
 ): string | null | undefined {
   for (const node of nodes) {
     if (node.id === id) return parentId;
@@ -64,7 +64,7 @@ function findParentId(
 function isDescendant(
   nodes: ChapterNode[],
   itemId: string,
-  targetId: string
+  targetId: string,
 ): boolean {
   const item = findNodeById(nodes, itemId);
   if (!item || !item.children) return false;
@@ -78,9 +78,9 @@ function isDescendant(
 // 기본 Mock 데이터
 const defaultChapters: ChapterNode[] = [
   {
-    id: "part-1",
+    id: "chapter-1",
     title: "1부: 여정의 시작",
-    type: "part",
+    type: "chapter",
     children: [
       {
         id: "chapter-1-1",
@@ -107,9 +107,9 @@ const defaultChapters: ChapterNode[] = [
     ],
   },
   {
-    id: "part-2",
+    id: "chapter-2",
     title: "2부: 성장",
-    type: "part",
+    type: "chapter",
     children: [
       {
         id: "chapter-2-1",
@@ -135,7 +135,7 @@ export function ChapterTree({
   const chapters = useMemo(() => initialChapters, [initialChapters]);
   const [isAdding, setIsAdding] = useState(false);
   const [addingType, setAddingType] = useState<"chapter" | "section">(
-    "chapter"
+    "chapter",
   );
   const [newChapterTitle, setNewChapterTitle] = useState("");
   const [addingToParent, setAddingToParent] = useState<string | null>(null);
@@ -156,7 +156,7 @@ export function ChapterTree({
 
   // 모두 접기/펼치기 상태 (undefined = 개별 제어, true/false = 강제 제어)
   const [forceExpandAll, setForceExpandAll] = useState<boolean | undefined>(
-    undefined
+    undefined,
   );
 
   // DnD Sensors
@@ -168,7 +168,7 @@ export function ChapterTree({
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    })
+    }),
   );
 
   useEffect(() => {
@@ -182,7 +182,7 @@ export function ChapterTree({
     onAddChapter?.(
       newChapterTitle.trim(),
       addingToParent || undefined,
-      addingType
+      addingType,
     );
     setNewChapterTitle("");
     setIsAdding(false);
@@ -191,7 +191,7 @@ export function ChapterTree({
 
   const handleStartAddChild = (
     parentId: string,
-    type: "chapter" | "section" = "chapter"
+    type: "chapter" | "section" = "chapter",
   ) => {
     setAddingToParent(parentId);
     setAddingType(type);
@@ -238,7 +238,7 @@ export function ChapterTree({
       }
 
       // 폴더인 경우 -> inside (폴더 안으로 이동)
-      if (overNode.type === "chapter" || overNode.type === "part") {
+      if (overNode.type === "chapter") {
         setDropIndicator({ id: overId, position: "inside" });
       } else {
         // 섹션인 경우: 드래그 방향(delta.y)으로 before/after 결정
@@ -251,7 +251,7 @@ export function ChapterTree({
         setDropIndicator({ id: overId, position });
       }
     },
-    [chapters]
+    [chapters],
   );
 
   // Drag End Handler - 순서 변경 + 폴더 이동 처리
@@ -280,7 +280,7 @@ export function ChapterTree({
     if (activeParentId === undefined || overParentId === undefined) return;
 
     // Case 1: 폴더 위에 드롭 → 폴더 안으로 이동
-    if (overNode.type === "chapter" || overNode.type === "part") {
+    if (overNode.type === "chapter") {
       // 순환 참조 방지
       if (isDescendant(chapters, activeIdValue, overIdValue)) {
         console.warn("Cannot move item into its own descendant");
@@ -293,7 +293,7 @@ export function ChapterTree({
         const parent = findNodeById(chapters, overIdValue);
         if (parent?.children) {
           const oldIndex = parent.children.findIndex(
-            (c) => c.id === activeIdValue
+            (c) => c.id === activeIdValue,
           );
           // 폴더 자체 위에 드롭한 경우이므로 첫 번째로 이동
           if (oldIndex !== -1 && oldIndex !== 0) {
@@ -302,7 +302,7 @@ export function ChapterTree({
             newOrder.unshift(removed);
             onReorderChapter?.(
               overIdValue,
-              newOrder.map((c) => c.id)
+              newOrder.map((c) => c.id),
             );
           }
         }

--- a/src/components/editor/sidebar/NodeIcon.tsx
+++ b/src/components/editor/sidebar/NodeIcon.tsx
@@ -14,9 +14,8 @@ export function NodeIcon({
   }
 
   switch (node.type) {
-    case "part":
     case "chapter":
-      // Folders (Parts & Chapters)
+      // Folders (Chapters)
       return isExpanded ? (
         <FolderOpen className="h-4 w-4 text-mocha-500" />
       ) : (

--- a/src/components/editor/sidebar/TreeItem.tsx
+++ b/src/components/editor/sidebar/TreeItem.tsx
@@ -57,9 +57,8 @@ export const TreeItem = memo(function TreeItem({
   forceExpanded,
 }: TreeItemProps) {
   const hasChildren = (node.children?.length || 0) > 0;
-  const isPart = node.type === "part";
   const isSelected = node.id === selectedId;
-  const isFolder = node.type === "chapter" || node.type === "part";
+  const isFolder = node.type === "chapter"; // chapter = 폴더 역할
 
   // 현재 이 폴더가 드래그 중인 아이템의 부모인지 확인
   const isParentOfActive = useMemo(() => {
@@ -105,13 +104,13 @@ export const TreeItem = memo(function TreeItem({
       // 드래그 중인 원래 위치는 희미하게 표시
       opacity: isDragging ? 0.3 : 1,
     }),
-    [transform, transition, isDragging]
+    [transform, transition, isDragging],
   );
 
   // Child IDs for nested SortableContext
   const childIds = useMemo(
     () => node.children?.map((c) => c.id) ?? [],
-    [node.children]
+    [node.children],
   );
 
   // 1. 기본 상태 및 동작 훅
@@ -132,7 +131,7 @@ export const TreeItem = memo(function TreeItem({
   } = useTreeItem({
     initialTitle: node.title,
     nodeId: node.id,
-    isPart,
+    isFolder,
     onSelect,
     onRename,
     forceExpanded,
@@ -155,7 +154,7 @@ export const TreeItem = memo(function TreeItem({
 
   const nextParentLines = useMemo(
     () => [...parentLines, !isLast],
-    [parentLines, isLast]
+    [parentLines, isLast],
   );
 
   return (
@@ -189,9 +188,9 @@ export const TreeItem = memo(function TreeItem({
           isDragging && "shadow-lg ring-2 ring-mocha-400 bg-card",
           // 폴더 드래그 오버 상태 - 강화된 하이라이트
           showDropInside &&
-          !isDragging &&
-          !isParentOfActive &&
-          "bg-emerald-100 ring-2 ring-emerald-500"
+            !isDragging &&
+            !isParentOfActive &&
+            "bg-emerald-100 ring-2 ring-emerald-500",
         )}
         style={{ marginLeft: `${level * 12}px` }}
         onClick={handleClick}
@@ -228,7 +227,7 @@ export const TreeItem = memo(function TreeItem({
             <div
               className={cn(
                 "absolute right-2 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full ring-1 ring-white",
-                statusColors[node.status]
+                statusColors[node.status],
               )}
               title={getStatusTitle(node.status)}
             />
@@ -275,13 +274,13 @@ export const TreeItem = memo(function TreeItem({
                   isSelected
                     ? "font-medium text-espresso-900"
                     : "text-foreground",
-                  node.isPlot && "italic text-muted-foreground"
+                  node.isPlot && "italic text-muted-foreground",
                 )}
               >
                 {node.title}
               </span>
-              {/* Character count */}
-              {!isPart && (node.characterCount || 0) > 0 && (
+              {/* Character count - 섹션에서만 표시 */}
+              {!isFolder && (node.characterCount || 0) > 0 && (
                 <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
                   {formatCharCount(node.characterCount!)}
                 </span>
@@ -292,15 +291,12 @@ export const TreeItem = memo(function TreeItem({
 
         {/* Action buttons (hover) */}
         <div className="absolute right-6 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-          {/* 폴더(chapter/part)에서만 섹션 추가 버튼 표시 */}
+          {/* 폴더(chapter)에서만 타입 선택 추가 버튼 표시 */}
           {isFolder && onAddChild && (
             <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddChild(node.id, "section");
-              }}
+              onClick={handleMenuButtonClick}
               className="p-1 hover:bg-mocha-400/10 rounded transition-colors"
-              title="추가"
+              title="추가 (폴더/섹션)"
             >
               <Plus className="h-3.5 w-3.5 text-mocha-500" />
             </button>

--- a/src/components/editor/sidebar/hooks/useTreeItem.ts
+++ b/src/components/editor/sidebar/hooks/useTreeItem.ts
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect, type MouseEvent } from "react";
 interface UseTreeItemProps {
   initialTitle: string;
   nodeId: string;
-  isPart: boolean;
+  isFolder: boolean; // chapter = 폴더 역할
   onSelect?: (id: string) => void;
   onRename?: (id: string, newTitle: string) => void;
   forceExpanded?: boolean; // 외부에서 모두 접기/펼치기 제어
@@ -12,7 +12,7 @@ interface UseTreeItemProps {
 export function useTreeItem({
   initialTitle,
   nodeId,
-  isPart,
+  isFolder,
   onSelect,
   onRename,
   forceExpanded,
@@ -26,11 +26,10 @@ export function useTreeItem({
   const itemRef = useRef<HTMLDivElement>(null);
 
   // forceExpanded가 변경되면 해당 값으로 동기화
-  useEffect(() => {
-    if (forceExpanded !== undefined) {
-      setIsExpanded(forceExpanded);
-    }
-  }, [forceExpanded]);
+  // 초기값으로 forceExpanded 사용, 이후 변경 시에만 동기화
+  if (forceExpanded !== undefined && forceExpanded !== isExpanded) {
+    setIsExpanded(forceExpanded);
+  }
 
   // Rename input focus effect
   useEffect(() => {
@@ -55,7 +54,7 @@ export function useTreeItem({
 
   const handleClick = () => {
     if (isRenaming) return;
-    if (isPart) {
+    if (isFolder) {
       setIsExpanded(!isExpanded);
     } else {
       onSelect?.(nodeId);

--- a/src/components/editor/sidebar/hooks/useTreeItemMenu.ts
+++ b/src/components/editor/sidebar/hooks/useTreeItemMenu.ts
@@ -1,5 +1,5 @@
 import { useState, type MouseEvent } from "react";
-import { FilePlus, Pencil, Trash2 } from "lucide-react";
+import { FilePlus, FolderPlus, Pencil, Trash2 } from "lucide-react";
 import type { MenuItemType } from "../ContextMenu";
 import type { ChapterNode } from "../types";
 
@@ -33,21 +33,26 @@ export function useTreeItemMenu({
     setShowMenu(true);
   };
 
-  // 폴더(chapter/part)인 경우에만 하위 섹션 추가 가능
+  // 폴더(chapter)인 경우에만 하위 항목 추가 가능
   // 섹션(section)에서는 하위 항목 생성 불가
-  const isFolder = node.type === "chapter" || node.type === "part";
+  const isFolder = node.type === "chapter";
 
   const menuItems: MenuItemType[] = [
-    // 폴더일 때만 "새 하위 섹션" 메뉴 표시
+    // 폴더일 때 "새 하위 폴더"와 "새 하위 섹션" 메뉴 표시
     ...(isFolder && onAddChild
       ? [
-        {
-          icon: FilePlus,
-          label: "새 하위 섹션",
-          onClick: () => onAddChild(node.id, "section"),
-        },
-        { type: "divider" as const },
-      ]
+          {
+            icon: FolderPlus,
+            label: "새 하위 폴더",
+            onClick: () => onAddChild(node.id, "chapter"),
+          },
+          {
+            icon: FilePlus,
+            label: "새 하위 섹션",
+            onClick: () => onAddChild(node.id, "section"),
+          },
+          { type: "divider" as const },
+        ]
       : []),
     {
       icon: Pencil,

--- a/src/components/editor/sidebar/types.ts
+++ b/src/components/editor/sidebar/types.ts
@@ -3,7 +3,7 @@
 export interface ChapterNode {
   id: string;
   title: string;
-  type: "part" | "chapter" | "section";
+  type: "chapter" | "section"; // chapter = 폴더 역할 (하위 폴더/섹션 포함 가능)
   characterCount?: number;
   isPlot?: boolean;
   isModified?: boolean;
@@ -18,7 +18,7 @@ export interface ChapterTreeProps {
   onAddChapter?: (
     title: string,
     parentId?: string,
-    type?: "chapter" | "section"
+    type?: "chapter" | "section",
   ) => void;
   onRenameChapter?: (id: string, newTitle: string) => void;
   onDeleteChapter?: (id: string) => void;

--- a/src/data/demoData.ts
+++ b/src/data/demoData.ts
@@ -98,12 +98,12 @@ export const DEMO_CHAPTER_CONTENTS: Record<string, string> = {
 // 데모용 챕터 트리 구조
 export const DEMO_CHAPTERS = [
   {
-    id: "part-1",
+    id: "chapter-demo-1",
     projectId: "demo",
     title: "제1부: 운명의 시작",
     content: "",
     order: 1,
-    type: "part" as const,
+    type: "chapter" as const,
     characterCount: 0,
     isPlot: false,
     createdAt: "2024-01-01",
@@ -112,7 +112,7 @@ export const DEMO_CHAPTERS = [
   {
     id: "chapter-1",
     projectId: "demo",
-    parentId: "part-1",
+    parentId: "chapter-demo-1",
     title: "제1장: 만남",
     content: "",
     order: 1,
@@ -164,7 +164,7 @@ export const DEMO_CHAPTERS = [
   {
     id: "chapter-2",
     projectId: "demo",
-    parentId: "part-1",
+    parentId: "chapter-demo-1",
     title: "제2장: 정령의 숲",
     content: "",
     order: 2,
@@ -201,12 +201,12 @@ export const DEMO_CHAPTERS = [
     updatedAt: "2024-01-01",
   },
   {
-    id: "part-2",
+    id: "chapter-demo-2",
     projectId: "demo",
     title: "제2부: 진실",
     content: "",
     order: 2,
-    type: "part" as const,
+    type: "chapter" as const,
     characterCount: 0,
     isPlot: true,
     createdAt: "2024-01-01",
@@ -215,7 +215,7 @@ export const DEMO_CHAPTERS = [
   {
     id: "chapter-3",
     projectId: "demo",
-    parentId: "part-2",
+    parentId: "chapter-demo-2",
     title: "제3장: 대적",
     content: "",
     order: 1,

--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -111,7 +111,7 @@ export const SAMPLE_CHAPTERS: Chapter[] = [
     title: "제1부: 시작의 장",
     content: "",
     order: 0,
-    type: "part",
+    type: "chapter", // 폴더 역할
     characterCount: 0,
     isPlot: false,
     createdAt: new Date().toISOString(),
@@ -175,7 +175,7 @@ export const SAMPLE_CHAPTERS: Chapter[] = [
     title: "제2부: 아르카디아",
     content: "",
     order: 1,
-    type: "part",
+    type: "chapter", // 폴더 역할
     characterCount: 0,
     isPlot: false,
     createdAt: new Date().toISOString(),
@@ -239,7 +239,7 @@ export const SAMPLE_CHAPTERS: Chapter[] = [
     title: "제3부: 전쟁",
     content: "",
     order: 2,
-    type: "part",
+    type: "chapter", // 폴더 역할
     characterCount: 0,
     isPlot: true,
     createdAt: new Date().toISOString(),
@@ -303,7 +303,7 @@ export const SAMPLE_CHAPTERS: Chapter[] = [
     title: "제4부: 결말",
     content: "",
     order: 3,
-    type: "part",
+    type: "chapter", // 폴더 역할
     characterCount: 0,
     isPlot: true,
     createdAt: new Date().toISOString(),

--- a/src/hooks/useCharacterGraphZoom.ts
+++ b/src/hooks/useCharacterGraphZoom.ts
@@ -11,8 +11,6 @@ interface UseZoomReturn {
   zoomState: ZoomState;
   zoomIn: () => void;
   zoomOut: () => void;
-  zoomIn: () => void;
-  zoomOut: () => void;
   resetZoom: () => void;
   centerAt: (x: number, y: number, scale?: number) => void;
 }

--- a/src/pages/editor/EditorPage.tsx
+++ b/src/pages/editor/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { Minimize2 } from "lucide-react";
 
@@ -37,9 +37,9 @@ import EditorRightSidebar from "@/components/editor/EditorRightSidebar";
 import SnapshotPanel from "@/components/editor/SnapshotPanel";
 import ExportModal from "@/components/editor/ExportModal";
 import DemoHeader from "@/components/editor/DemoHeader";
-import { EditorSettingsPanel } from "@/components/editor/settings/EditorSettingsPanel";
 // SectionStrip removed - minimizing distractions for writer focus
 // ScriveningsEditor & OutlineView removed (moved to EditorContent)
+// EditorSettingsPanel removed (not currently used)
 
 // Refactored Hooks
 import { useEditorHandlers } from "./hooks/useEditorHandlers";
@@ -62,14 +62,14 @@ import { useBulkDocumentContent } from "@/hooks/useDocuments";
 interface DemoChapterTreeNode {
   id: string;
   title: string;
-  type: "part" | "chapter" | "section";
+  type: "chapter" | "section"; // chapter = 폴더 역할
   characterCount?: number;
   isPlot?: boolean;
   children?: DemoChapterTreeNode[];
 }
 
 function buildDemoChapterTree(
-  chapters: typeof DEMO_CHAPTERS
+  chapters: typeof DEMO_CHAPTERS,
 ): DemoChapterTreeNode[] {
   const map = new Map<string, DemoChapterTreeNode>();
   const roots: DemoChapterTreeNode[] = [];
@@ -149,11 +149,11 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
   const editorContentRef = useRef<EditorContentHandle>(null);
   // selectedFolderId = currently selected folder (chapter) in sidebar
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(
-    isDemo ? "chapter-1" : null
+    isDemo ? "chapter-1" : null,
   );
   // selectedSectionId = currently editing section in editor
   const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
-    isDemo ? "chapter-1-1" : null
+    isDemo ? "chapter-1-1" : null,
   );
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
@@ -163,19 +163,19 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
 
   // Editor Setting Store - Typewriter mode & Focus mode
   const typewriterMode = useEditorSettingStore(
-    (state) => state.behavior.typewriterMode
+    (state) => state.behavior.typewriterMode,
   );
   const toggleTypewriterMode = useEditorSettingStore(
-    (state) => state.toggleTypewriterMode
+    (state) => state.toggleTypewriterMode,
   );
   const isTypewriterMode = typewriterMode !== "off";
 
   // Focus mode from settings store
   const isFocusMode = useEditorSettingStore(
-    (state) => state.behavior.focusMode
+    (state) => state.behavior.focusMode,
   );
   const toggleFocusMode = useEditorSettingStore(
-    (state) => state.toggleFocusMode
+    (state) => state.toggleFocusMode,
   );
 
   // Project ID - use URL param, fallback to SAMPLE_PROJECT_ID for demo/default
@@ -195,9 +195,9 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
       isDemo
         ? []
         : Object.values(allDocuments).filter(
-          (doc) => doc.projectId === projectId
-        ),
-    [allDocuments, projectId, isDemo]
+            (doc) => doc.projectId === projectId,
+          ),
+    [allDocuments, projectId, isDemo],
   );
 
   const previewChapters = useMemo(() => {
@@ -216,7 +216,7 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
     if (isDemo) return "데모 작품";
     if (project?.title) return project.title;
     const folder = localDocuments?.find(
-      (doc: Document) => doc.type === "folder"
+      (doc: Document) => doc.type === "folder",
     );
     return folder?.title || "내 작품";
   }, [project?.title, localDocuments, isDemo]);
@@ -227,7 +227,7 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
 
   const { tree: documentTree, documents } = useDocumentTree(projectId);
   const { content: documentContent, saveContent } = useDocumentContent(
-    isDemo ? null : selectedSectionId
+    isDemo ? null : selectedSectionId,
   );
   const {
     createDocument,
@@ -247,7 +247,6 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
     saveContentRef,
     saveTimeoutRef,
     handleSelectFolder,
-    handleSelectSection,
     handleContentChange,
     handleCharacterCountChange,
     handleAddChapter,
@@ -372,14 +371,14 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
         import("@/stores/useWritingStatsStore").then(
           ({ useWritingStatsStore }) => {
             useWritingStatsStore.getState().recordActivity(delta);
-          }
+          },
         );
       }
       prevCountRef.current = count;
 
       handleCharacterCountChange(count, setCharacterCount);
     },
-    [handleCharacterCountChange]
+    [handleCharacterCountChange],
   );
 
   // ============================================================
@@ -450,7 +449,7 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
       setSplitState(null); // 일반 생성 모드
       setCreateSectionModalOpen(true);
     },
-    [selectedSectionId, documents]
+    [selectedSectionId, documents],
   );
 
   const handleConfirmCreateSection = async (title: string) => {
@@ -507,7 +506,7 @@ export default function EditorPage({ isDemo = false }: EditorPageProps) {
     <div
       className={cn(
         "flex flex-col bg-background text-foreground",
-        isDemo ? "h-screen" : "h-full"
+        isDemo ? "h-screen" : "h-full",
       )}
     >
       {/* Demo Header */}

--- a/src/pages/export/ExportPage.tsx
+++ b/src/pages/export/ExportPage.tsx
@@ -70,13 +70,13 @@ export default function ExportPage() {
   // Filter documents for current project
   // If no documents found for projectId, fall back to sample project
   let projectDocuments = documents.filter(
-    (doc: Document) => doc.projectId === projectId
+    (doc: Document) => doc.projectId === projectId,
   );
 
   // Fallback to sample project if no documents found
   if (projectDocuments.length === 0) {
     projectDocuments = documents.filter(
-      (doc: Document) => doc.projectId === SAMPLE_PROJECT_ID
+      (doc: Document) => doc.projectId === SAMPLE_PROJECT_ID,
     );
   }
 
@@ -164,7 +164,7 @@ export default function ExportPage() {
                 projectId,
                 documents: projectDocuments,
               },
-              projectTitle
+              projectTitle,
             );
             break;
           case "epub":
@@ -194,7 +194,7 @@ export default function ExportPage() {
         }, 3000);
       }
     },
-    [projectDocuments, projectTitle, projectId]
+    [projectDocuments, projectTitle, projectId],
   );
 
   const handleImportClick = () => {
@@ -262,7 +262,7 @@ export default function ExportPage() {
       (doc) =>
         doc.projectId === targetProjectId &&
         doc.type === "folder" &&
-        doc.title === "가져온 문서"
+        doc.title === "가져온 문서",
     )?.id;
 
     if (!importFolderId) {
@@ -360,7 +360,7 @@ export default function ExportPage() {
       console.error("Import error:", error);
       setImportStatus("error");
       setImportError(
-        error instanceof Error ? error.message : "가져오기에 실패했습니다."
+        error instanceof Error ? error.message : "가져오기에 실패했습니다.",
       );
       setTimeout(() => {
         setImportStatus("idle");
@@ -452,7 +452,7 @@ export default function ExportPage() {
                   >
                     {getButtonIcon(
                       format.id,
-                      exportStatus[format.id] || "idle"
+                      exportStatus[format.id] || "idle",
                     )}
                   </div>
                   <h3 className="font-medium">{format.title}</h3>
@@ -497,13 +497,15 @@ export default function ExportPage() {
                         ${importStatus === "loading" ? "border-mocha-400 bg-mocha-400/10" : ""}`}
             >
               <div className="w-16 h-16 bg-cloud-50 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  ) : importStatus === "success" ? (
-                    <Check className="h-8 w-8 text-status-success" />
-                  ) : importStatus === "error" ? (
-                    <AlertCircle className="h-8 w-8 text-status-error" />
-                  ) : (
-                    <Archive className="h-8 w-8 text-muted-foreground" />
-                  )}
+                {importStatus === "loading" ? (
+                  <Loader2 className="h-8 w-8 text-mocha-500 animate-spin" />
+                ) : importStatus === "success" ? (
+                  <Check className="h-8 w-8 text-status-success" />
+                ) : importStatus === "error" ? (
+                  <AlertCircle className="h-8 w-8 text-status-error" />
+                ) : (
+                  <Archive className="h-8 w-8 text-muted-foreground" />
+                )}
               </div>
 
               {importStatus === "success" ? (

--- a/src/pages/world/WorldPage.tsx
+++ b/src/pages/world/WorldPage.tsx
@@ -181,7 +181,6 @@ export default function WorldPage() {
               links={links}
               onNodeClick={handleNodeClick}
               selectedNodeId={selectedCharacter?.id || null}
-              selectedNodeId={selectedCharacter?.id || null}
               relationTypeFilter={relationTypeFilter}
               highlightedNodeIds={searchHighlightedIds}
               ref={graphRef}


### PR DESCRIPTION
##  변경 사항

### part 타입 제거 및 인라인 생성 UX 개선

- ChapterNode.type에서 part 타입 제거 (chapter가 유일한 폴더 역할)
- useTreeItemMenu에 새 하위 폴더 메뉴 옵션 추가
- 기존 빌드 오류 수정 (useCharacterGraphZoom, WorldPage, ExportPage)

##  체크리스트

- [x] 빌드 성공 확인
- [x] 타입 체크 통과

##  Merge 가이드

- Target: dev
- Squash and Merge 권장

Closes stolink/stolink-manage#59