### PR TITLE
feat: 커뮤니티 배포 기능 구현 (Draft API 연동)

### DIFF
--- a/src/components/editor/ExportModal.tsx
+++ b/src/components/editor/ExportModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Download,
   FileText,
@@ -23,6 +23,8 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { Character } from "@/types/character";
+import { draftService } from "@/services/draftService";
+import { useToast } from "@/hooks/useToast";
 
 interface ExportModalProps {
   isOpen: boolean;
@@ -39,7 +41,8 @@ interface ExportModalProps {
     type: string;
     strength: number;
   }>;
-  documents?: { id: string; title: string; content?: string }[];
+  documents?: { id: string; title: string; content?: string; type?: string }[];
+  projectId?: string; // Add projectId to props
 }
 
 // 플랫폼 프리셋 정의
@@ -101,6 +104,7 @@ export default function ExportModal({
   characters = [],
   links = [],
   documents = [],
+  projectId, // Destructure projectId
 }: ExportModalProps) {
   const [activeTab, setActiveTab] = useState(initialTab);
   const [selectedPreset, setSelectedPreset] = useState(PRESETS[0].id);
@@ -110,20 +114,37 @@ export default function ExportModal({
 
   // Initialize selected document
   // Compute initial doc ID without setState in effect
+  // 폴더(type: 'folder')를 제외하고 문서(type: 'text')만 필터링
+  const textDocuments = documents.filter((d) => d.type !== "folder");
+
   const initialDocId = (() => {
-    if (documents.length === 0) return "";
-    if (currentId && documents.some((d) => d.id === currentId))
+    if (textDocuments.length === 0) return "";
+    if (currentId && textDocuments.some((d) => d.id === currentId))
       return currentId;
     const matched =
-      documents.find((d) => d.title === title) ||
-      documents.find((d) => d.content);
-    return matched?.id || "";
+      textDocuments.find((d) => d.title === title) ||
+      textDocuments.find((d) => d.content);
+    return matched?.id || textDocuments[0]?.id || "";
   })();
 
   const [selectedDocId, setSelectedDocId] = useState<string>(initialDocId);
   const [includeCharacters, setIncludeCharacters] = useState(true);
   const [includeGraph, setIncludeGraph] = useState(true);
+
+  // documents가 로드된 후 selectedDocId가 비어있으면 첫 번째 문서로 설정
+  useEffect(() => {
+    if (!selectedDocId && textDocuments.length > 0) {
+      setSelectedDocId(textDocuments[0].id);
+    }
+  }, [textDocuments, selectedDocId]);
+
+  // 커뮤니티 배포 관련 상태
   const [isPublishing, setIsPublishing] = useState(false);
+  const { toast } = useToast();
+
+  // 커뮤니티 URL (환경 변수 또는 기본값)
+  const COMMUNITY_URL =
+    import.meta.env.VITE_COMMUNITY_URL || "http://localhost:5174";
 
   // Derived content based on selection
   const targetDoc = documents.find((d) => d.id === selectedDocId);
@@ -205,54 +226,82 @@ export default function ExportModal({
     URL.revokeObjectURL(url);
   };
 
-  // Mock Publish Handler
+  // 커뮤니티 배포 핸들러 (Draft 생성 및 리다이렉트)
   const handlePublish = async () => {
+    if (!selectedDocId || selectedDocId === "") {
+      toast({
+        title: "배포할 섹션을 선택해주세요",
+        description: "문서 목록에서 배포할 항목을 선택해야 합니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsPublishing(true);
 
-    // Simulate API call / Packaging
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    try {
+      // 1. 스냅샷 데이터 생성
+      const graphSnapshot = {
+        // 노드: D3 렌더링용 최소 데이터
+        nodes: characters.map((c) => ({
+          id: c._id,
+          name: c.profile?.name || "이름 없음",
+          role: c.role,
+          group: c.profile?.faction?.name || undefined,
+          imageUrl: c.imageUrl || undefined,
+        })),
 
-    // In a real app, this would upload to server.
-    // Here we'll download a JSON package representing the published state.
-    // In a real app, this would upload to server.
-    // Here we'll download a JSON package representing the published state.
-    const packageData = {
-      title: targetTitle,
-      content: targetContent, // HTML content
-      publishedAt: new Date().toISOString(),
-      stats: {
-        wordCount,
-        readTime,
-      },
-      snapshots: {
-        characters: includeCharacters ? characters : null,
-        graph: includeGraph
-          ? {
-              nodes: characters.map((c) => ({
-                id: c._id,
-                name: c.profile?.name || "이름 없음",
-                role: c.role,
-                group: c.profile?.faction?.name || "무소속",
-                imageUrl: undefined, // 새 스키마에 imageUrl 없음
-              })),
-              links,
-            }
-          : null,
-      },
-    };
+        // 링크: 관계 정보 + 히스토리
+        links: links.map((l) => {
+          const relation = characters
+            .find((c) => c._id === l.source)
+            ?.relations?.graph?.find((r) => r.target === l.target);
+          return {
+            ...l,
+            id: String(l.id),
+            description: relation?.description,
+            history: relation?.history || undefined,
+          };
+        }),
 
-    const blob = new Blob([JSON.stringify(packageData, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${targetTitle}_publish_package.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+        // 프로필: 노드 클릭 시 상세 정보
+        profiles: Object.fromEntries(
+          characters.map((c) => [
+            c._id,
+            {
+              id: c._id,
+              name: c.profile?.name,
+              age: c.profile?.age || undefined,
+              gender: c.profile?.gender,
+              personality: c.personality?.core_traits,
+              backstory: c.profile?.backstory,
+              imageUrl: c.imageUrl || undefined,
+            },
+          ]),
+        ),
+      };
 
-    setIsPublishing(false);
-    onClose();
+      // 2. Draft API 호출
+      await draftService.create({
+        documentId: selectedDocId,
+        projectId, // 선택 사항
+        title: targetTitle,
+        content: targetContent,
+        graphSnapshot,
+      });
+
+      // 3. 커뮤니티로 리다이렉트 (메인으로 이동, 파라미터 없음)
+      window.location.href = COMMUNITY_URL;
+    } catch (error) {
+      console.error("Draft 저장 실패:", error);
+      toast({
+        title: "배포 준비 실패",
+        description: "잠시 후 다시 시도해주세요.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsPublishing(false);
+    }
   };
 
   return (

--- a/src/services/draftService.ts
+++ b/src/services/draftService.ts
@@ -1,0 +1,28 @@
+/**
+ * Draft Service
+ * 커뮤니티 배포를 위한 임시 저장(Draft) API 서비스
+ */
+
+import api from "@/api/client";
+import type { ApiResponse } from "@/types/api";
+import type { CreateDraftRequest, Draft } from "@/types/publish";
+
+export const draftService = {
+  /**
+   * Draft 생성 - 스냅샷 데이터를 백엔드에 임시 저장
+   * @param data Draft 생성 요청 데이터 (스냅샷 포함)
+   * @returns 생성된 Draft 정보 (id 포함)
+   */
+  create: async (data: CreateDraftRequest) => {
+    const response = await api.post<ApiResponse<Draft>>("/drafts", data);
+    return response.data;
+  },
+
+  /**
+   * Draft 조회 (참고용, 주로 커뮤니티 서비스에서 사용)
+   */
+  get: async (id: string) => {
+    const response = await api.get<ApiResponse<Draft>>(`/drafts/${id}`);
+    return response.data;
+  },
+};

--- a/src/types/publish.ts
+++ b/src/types/publish.ts
@@ -1,0 +1,63 @@
+/**
+ * Publish Types
+ * 커뮤니티 배포 및 Draft 관련 타입 정의
+ */
+
+// 관계도 노드 (D3 렌더링용)
+export interface GraphNode {
+  id: string; // 캐릭터 UUID
+  name: string; // 표시 이름
+  role: string; // protagonist, supporting 등 (색상 결정)
+  group?: string; // 소속/팩션 (클러스터링용)
+  imageUrl?: string; // 노드 이미지
+}
+
+// 관계도 간선
+export interface GraphLink {
+  source: string; // 출발 노드 ID
+  target: string; // 도착 노드 ID
+  id: string; // 링크 고유 ID (source-target)
+  type: string; // friendly, hostile 등 (선 스타일)
+  strength: number; // 1~10 (선 굵기)
+  description?: string; // 관계 설명
+  history?: string | null; // 관계 히스토리 (간선 클릭 시 표시, 현재는 문자열)
+}
+
+// 캐릭터 상세 프로필 (노드 클릭 시 표시)
+export interface ProfileSnapshot {
+  id: string;
+  name: string;
+  age?: number;
+  gender?: string;
+  personality?: string[]; // 핵심 성격 키워드
+  backstory?: string;
+  imageUrl?: string;
+}
+
+// Draft 생성 요청 (API RequestBody)
+export interface CreateDraftRequest {
+  documentId: string; // 필수: 배포할 섹션 ID
+  projectId?: string; // 선택: 원본 프로젝트 ID
+  title: string; // 섹션 제목
+  content: string; // HTML 본문
+  graphSnapshot: {
+    nodes: GraphNode[];
+    links: GraphLink[];
+    profiles: Record<string, ProfileSnapshot>;
+  };
+}
+
+// Draft 응답
+export interface Draft {
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+// 배포 완료된 게시글 (참고용, 현재 프론트에서 직접 사용하진 않음)
+export interface PublishedPost {
+  id: string;
+  publishedUrl: string;
+  publishedAt: string;
+  status: "published" | "draft";
+}


### PR DESCRIPTION
## 📋 변경 사항

커뮤니티 배포 기능을 구현했습니다.

- 작가가 "커뮤니티에 배포하기" 버튼 클릭 시 Draft API 호출
- 소설 섹션 + 관계도 스냅샷을 백엔드에 저장
- 저장 성공 시 독자 서비스 URL로 리다이렉트

### 주요 변경
- `types/publish.ts`: Draft 관련 타입 정의 (신규)
- `services/draftService.ts`: Draft API 호출 서비스 (신규)
- `ExportModal.tsx`: 배포 로직 구현, 폴더 제외 필터링

## 📁 변경된 파일

- `src/types/publish.ts` (신규)
- `src/services/draftService.ts` (신규)
- `src/components/editor/ExportModal.tsx` (수정)

## ✅ 체크리스트

- [x] 빌드 성공 확인
- [x] 로컬 테스트 완료
- [x] 타입 체크 통과

## 🔀 Merge 가이드

- Target: dev
- Squash and Merge 권장


Closes stolink/stolink-manage#94
