### PR TITLE
fix: 배포 환경변수명 VITE_API_BASE_URL로 수정

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          VITE_API_URL: ${{ vars.VITE_API_URL_DEV }}
+          VITE_API_BASE_URL: "https://${{ vars.CLOUDFRONT_URL_DEV }}/api"
           REACT_APP_MEDIA_URL: "https://${{ vars.CLOUDFRONT_URL_DEV }}/media"
 
       - name: Generate version info


### PR DESCRIPTION
## 📋 변경 사항

- 배포 시 환경변수명이 코드와 불일치하여 API 호출이 실패하던 문제 수정
- `VITE_API_URL` → `VITE_API_BASE_URL`로 변경 (코드에서 사용하는 변수명과 일치)
- CloudFront URL에서 직접 API 경로 생성하도록 변경

## 📁 변경된 파일

- `.github/workflows/deploy_dev.yml`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
