### PR TITLE
fix: 환경변수명 VITE_API_URL로 통일

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          VITE_API_URL: ${{ vars.VITE_API_URL }}
+          VITE_API_URL: "https://${{ vars.CLOUDFRONT_URL }}/api"
           REACT_APP_MEDIA_URL: "https://${{ vars.CLOUDFRONT_URL }}/media"
 
       - name: Generate version info

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          VITE_API_BASE_URL: "https://${{ vars.CLOUDFRONT_URL_DEV }}/api"
+          VITE_API_URL: "https://${{ vars.CLOUDFRONT_URL_DEV }}/api"
           REACT_APP_MEDIA_URL: "https://${{ vars.CLOUDFRONT_URL_DEV }}/media"
 
       - name: Generate version info

--- a/src/services/graphApi.ts
+++ b/src/services/graphApi.ts
@@ -2,8 +2,7 @@ import axios from "axios";
 import type { NetworkNode, NetworkLink } from "@/types/network";
 
 // Default to localhost:8080 if not specified in env
-const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 const client = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## 📋 변경 사항

- 환경변수명 `VITE_API_URL`로 통일
- `deploy.yml`, `deploy_dev.yml`: CloudFront URL에서 직접 API 경로 생성
- `graphApi.ts`: `VITE_API_URL` 사용으로 코드 통일

## 📁 변경된 파일

- `.github/workflows/deploy.yml`
- `.github/workflows/deploy_dev.yml`
- `src/services/graphApi.ts`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
