### PR TITLE
refactor: graphApi.ts 변수명 API_URL로 통일

### DIFF
--- a/src/services/graphApi.ts
+++ b/src/services/graphApi.ts
@@ -2,10 +2,10 @@ import axios from "axios";
 import type { NetworkNode, NetworkLink } from "@/types/network";
 
 // Default to localhost:8080 if not specified in env
-const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 const client = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: API_URL,
   timeout: 5000,
 });
 


### PR DESCRIPTION
## 📋 변경 사항

- `graphApi.ts` 변수명 `API_BASE_URL` → `API_URL`로 통일

## 📁 변경된 파일

- `src/services/graphApi.ts`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
