### PR TITLE
feat(export): 캐릭터 프로필 스냅샷에 전체 데이터 포함

### DIFF
--- a/src/components/editor/ExportModal.tsx
+++ b/src/components/editor/ExportModal.tsx
@@ -273,12 +273,31 @@ export default function ExportModal({
             c._id,
             {
               id: c._id,
+              // Basic profile
               name: c.profile?.name,
               age: c.profile?.age || undefined,
               gender: c.profile?.gender,
-              personality: c.personality?.coreTraits,
-              backstory: c.profile?.backstory,
+              role: c.role,
               imageUrl: c.imageUrl || undefined,
+              // Extended profile
+              occupation: c.profile?.occupation || undefined,
+              birthplace: c.profile?.birthplace || undefined,
+              family: c.profile?.family || undefined,
+              backstory: c.profile?.backstory || undefined,
+              faction: c.profile?.faction?.name || undefined,
+              aliases: c.aliases || undefined,
+              firstAppearance: c.firstAppearance || undefined,
+              // Personality
+              personality: c.personality || undefined,
+              // Appearance
+              appearance: c.appearance || undefined,
+              // Motivation & Mood
+              motivation: c.motivation || undefined,
+              currentMood: c.currentMood || undefined,
+              // Relations (already have graph, but include full data for context)
+              relations: c.relations || undefined,
+              // Meta
+              meta: c.meta || undefined,
             },
           ]),
         ),
@@ -294,7 +313,7 @@ export default function ExportModal({
         title: targetTitle,
         content: targetContent,
         graphSnapshot,
-        workTitle: projectTitle,
+        workTitle: projectTitle || targetTitle || "제목 없음",
         workSynopsis: projectDescription,
         workGenre: projectGenre,
         workCoverUrl: projectCoverImage,

--- a/src/types/publish.ts
+++ b/src/types/publish.ts
@@ -29,9 +29,61 @@ export interface ProfileSnapshot {
   name: string;
   age?: number;
   gender?: string;
-  personality?: string[]; // 핵심 성격 키워드
-  backstory?: string;
+  role?: string;
   imageUrl?: string;
+  // Extended profile
+  occupation?: string;
+  birthplace?: string;
+  family?: string;
+  backstory?: string;
+  faction?: string;
+  aliases?: string[];
+  firstAppearance?: string;
+  // Personality (full object, not just coreTraits)
+  personality?: {
+    coreTraits?: string[];
+    strengths?: string[];
+    flaws?: string[];
+    values?: string[];
+  };
+  // Appearance (full object)
+  appearance?: {
+    physique?: string;
+    skinTone?: string;
+    eyes?: string;
+    nose?: string;
+    mouth?: string;
+    hairStyle?: string;
+    hairColor?: string;
+    attire?: string | string[];
+    expression?: string;
+    scarsTattoos?: string | string[];
+    styleContext?: {
+      artStyle?: string;
+    };
+  };
+  // Motivation & Mood
+  motivation?: string;
+  currentMood?: {
+    emotion?: string;
+    trigger?: string | null;
+    intensity?: number;
+  };
+  // Relations
+  relations?: {
+    graph?: Array<{
+      target: string;
+      type: string;
+      description?: string;
+      history?: string | null;
+      strength?: number;
+    }>;
+  };
+  // Meta
+  meta?: {
+    createdAt?: string | null;
+    updatedAt?: string | null;
+  };
 }
 
 // Draft 생성 요청 (API RequestBody)


### PR DESCRIPTION
## 📋 변경 사항

캐릭터 관계도 스냅샷에 전체 프로필 데이터를 포함하도록 개선했습니다.

### 주요 변경 내용
- **ProfileSnapshot 타입 확장**: occupation, birthplace, family, faction, aliases, firstAppearance 등 확장 프로필 필드 추가
- **Personality/Appearance 전체 객체 포함**: coreTraits뿐 아니라 strengths, flaws, values 등 전체 성격 정보와 외모 정보 포함
- **Relations/Mood/Meta 추가**: 캐릭터 관계, 현재 감정 상태, 메타 정보까지 스냅샷에 포함
- **workTitle 기본값 처리**: projectTitle이 없을 경우 targetTitle 또는 "제목 없음"으로 폴백

### 목적
Storead(커뮤니티)에서 캐릭터 노드 클릭 시 상세 프로필을 표시할 수 있도록 충분한 데이터를 제공합니다.

## 📁 변경된 파일

- `src/components/editor/ExportModal.tsx` - 스냅샷 생성 로직에 전체 프로필 데이터 포함
- `src/types/publish.ts` - ProfileSnapshot 타입 정의 확장

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 타입 체크 통과 (`tsc --noEmit`)

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
