### PR TITLE
fix(manuscript): 원고 업로드 500 에러 해결 (FormData 적용)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,9 +11,9 @@ interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
 export const api = axios.create({
   baseURL: API_URL,
   withCredentials: true, // 쿠키 자동 전송
-  headers: {
-    "Content-Type": "application/json",
-  },
+  // Content-Type은 axios가 데이터 타입에 따라 자동 설정
+  // - 일반 객체: application/json
+  // - FormData: multipart/form-data
 });
 
 // Request interceptor: X-User-Id 추가 (선택적)

--- a/src/services/manuscriptService.ts
+++ b/src/services/manuscriptService.ts
@@ -21,15 +21,22 @@ export const manuscriptService = {
    * 원고 업로드 (비동기 처리 시작)
    * POST /api/projects/{projectId}/manuscript/upload
    * Response: 202 Accepted
+   *
+   * 백엔드가 MultipartFile을 기대하므로 FormData로 전송
    */
   upload: async (
     projectId: string,
     content: string,
     filename?: string,
   ): Promise<ApiResponse<ManuscriptUploadResponse>> => {
+    const formData = new FormData();
+    const blob = new Blob([content], { type: "text/plain; charset=utf-8" });
+    formData.append("file", blob, filename || "manuscript.txt");
+
     const response = await api.post<ApiResponse<ManuscriptUploadResponse>>(
       `/projects/${projectId}/manuscript/upload`,
-      { content, filename },
+      formData,
+      // Content-Type은 axios가 FormData 감지 시 자동 설정
     );
     return response.data;
   },


### PR DESCRIPTION
## 📋 변경 사항

원고 가저오기 기능에서 발생하던 500 에러를 해결했습니다.
백엔드가 `MultipartFile` 형태로 원고 파일을 기대하는 반면, 프론트엔드에서는 JSON 객체로 전송하고 있어 발생하던 타입 불일치 문제를 해결했습니다.

### 주요 변경 내용
- **`manuscriptService.upload` 메서드 수정**: `FormData` 객체를 생성하여 파일을 `multipart/form-data` 형식으로 전송하도록 변경했습니다.
- **`api/client.ts` axios 설정 수정**: 기본 헤더에 강제로 설정되어 있던 `Content-Type: application/json`을 제거하여, axios가 데이터 타입(FormData 등)에 따라 적절한 Content-Type을 자동 설정할 수 있도록 개선했습니다.

## 📁 변경된 파일

- `src/services/manuscriptService.ts`
- `src/api/client.ts`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] 서재 페이지에서 로컬 txt 파일 업로드 테스트 (정상 동작 확인)

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
