### PR TITLE
refactor: production 배포 트리거 브랜치를 main에서 release로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main # production 환경
+      - release # production 환경
       - dev # develop 환경
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # 브랜치에 따라 환경 자동 선택
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'develop' }}
+    environment: ${{ github.ref == 'refs/heads/release' && 'production' || 'develop' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -62,7 +62,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     # 브랜치에 따라 환경 자동 선택
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'develop' }}
+    environment: ${{ github.ref == 'refs/heads/release' && 'production' || 'develop' }}
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -108,7 +108,7 @@ jobs:
 
       - name: Deployment Summary
         run: |
-          ENVIRONMENT=${{ github.ref == 'refs/heads/main' && 'production' || 'develop' }}
+          ENVIRONMENT=${{ github.ref == 'refs/heads/release' && 'production' || 'develop' }}
           echo "## 🚀 Frontend Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 📋 변경 사항

- Production 배포 트리거 브랜치를 `main`에서 `release`로 변경
- 모든 브랜치 조건문(`github.ref == 'refs/heads/main'`)을 `release` 기준으로 수정

## 📁 변경된 파일

- `.github/workflows/deploy.yml`

## ✅ 체크리스트

- [ ] 빌드 성공 확인 (`npm run build`)
- [ ] 로컬 테스트 완료

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
