### PR TITLE
fix: 챗봇 API 연동 오류 수정 (404, 422 에러)

### DIFF
--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { useAuthStore } from "@/stores";
 
-const API_URL = import.meta.env.VITE_API_URL || "/ai-api";
+const CHAT_API_URL = "/ai-api";
 
 /**
  * RAG 검색 결과 소스 청크
@@ -102,14 +102,14 @@ export function useChatStream(options?: UseChatStreamOptions) {
         };
 
         // Corrected path from /ai/chat/stream to /chat/stream as per guide
-        const response = await fetch(`${API_URL}/chat/stream`, {
+        const response = await fetch(`${CHAT_API_URL}/chat/stream`, {
           method: "POST",
           headers,
           body: JSON.stringify({
             message,
-            projectId: projectId,
-            userId: userId,
-            sessionId: sessionId,
+            project_id: projectId,
+            user_id: userId,
+            session_id: sessionId,
           }),
           signal: abortControllerRef.current.signal,
           credentials: "include", // 쿠키 자동 전송
@@ -226,10 +226,10 @@ export function useChatStream(options?: UseChatStreamOptions) {
 
     // Call stop endpoint as per guide
     try {
-      await fetch(`${API_URL}/chat/stop`, {
+      await fetch(`${CHAT_API_URL}/chat/stop`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId }),
+        body: JSON.stringify({ session_id: sessionId }),
       });
     } catch (err) {
       console.error("Failed to stop generation:", err);


### PR DESCRIPTION
### 🛠️ 수정 내용
#### [Frontend] [useChatStream.ts](cci:7://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/hooks/useChatStream.ts:0:0-0:0) 경로 및 변수명 수정
1. **API 요청 경로 변경 (404 Error Fix)**
   - 기존의 메인 API 경로(`/api`) 대신 챗봇 서비스 전용 경로(`/ai-api`)를 사용하도록 변경했습니다.
   - 로컬에서는 `vite` 프록시, 배포 시엔 Nginx 라우팅을 통해 챗봇 컨테이너로 직접 전달됩니다.
   - 변경: `API_URL` → `CHAT_API_URL = "/ai-api"`
2. **요청 본문 필드명 변경 (422 Error Fix)**
   - 백엔드(FastAPI) Pydantic 모델 검증 실패 문제를 해결했습니다.
   - 변경: `projectId` → `project_id`, `userId` → `user_id` (Camel Case → Snake Case)
### ✅ 검증 방법
1. 프로젝트 접속 후 우측 챗봇(AI Assistant) 패널 실행
2. 아무 질문이나 입력 (예: "안녕")
3. 개발자 도구 Network 탭에서 `POST /ai-api/chat/stream` 요청이 200 OK로 성공하는지 확인