### PR TITLE
feat(chat): implement project-based session persistence

### DIFF
--- a/src/components/editor/AIAssistantPanel.tsx
+++ b/src/components/editor/AIAssistantPanel.tsx
@@ -39,12 +39,20 @@ export default function AIAssistantPanel({ projectId }: AIAssistantPanelProps) {
     sendMessage,
     cancelStream,
     resetSession,
+    loadHistory,
     clearAnalysisComplete,
   } = useChatStream({
     onError: (error) => {
       console.error("AI Chat error:", error);
     },
   });
+
+  // 페이지 진입 시 히스토리 로드
+  useEffect(() => {
+    if (projectId) {
+      loadHistory(projectId);
+    }
+  }, [projectId, loadHistory]);
 
   // 분석 완료 애니메이션 표시 상태
   const [showCompleteAnimation, setShowCompleteAnimation] = useState(false);
@@ -106,7 +114,7 @@ export default function AIAssistantPanel({ projectId }: AIAssistantPanelProps) {
         <Button
           variant="ghost"
           size="icon"
-          onClick={resetSession}
+          onClick={() => resetSession(projectId ?? undefined)}
           className="h-9 w-9 text-mocha-300 hover:text-mocha-600 hover:bg-mocha-50 transition-all duration-300 rounded-xl"
           title="새 대화 시작"
         >

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -59,7 +59,7 @@ export function useChatStream(options?: UseChatStreamOptions) {
   const [streaming, setStreaming] = useState(false);
   const [currentResponse, setCurrentResponse] = useState("");
   const [currentSources, setCurrentSources] = useState<SourceChunk[]>([]);
-  const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [analysisComplete, setAnalysisComplete] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -74,6 +74,12 @@ export function useChatStream(options?: UseChatStreamOptions) {
       if (!userId) {
         options?.onError?.("로그인이 필요합니다.");
         return;
+      }
+
+      // 세션 ID 결정: userId-projectId 조합 (프로젝트 단위 고정)
+      const currentSessionId = sessionId ?? `${userId}-${projectId}`;
+      if (!sessionId) {
+        setSessionId(currentSessionId);
       }
 
       // 사용자 메시지 추가
@@ -109,7 +115,7 @@ export function useChatStream(options?: UseChatStreamOptions) {
             message,
             project_id: projectId,
             user_id: userId,
-            session_id: sessionId,
+            session_id: currentSessionId,
           }),
           signal: abortControllerRef.current.signal,
           credentials: "include", // 쿠키 자동 전송
@@ -239,11 +245,48 @@ export function useChatStream(options?: UseChatStreamOptions) {
     }
   }, [sessionId]);
 
-  const resetSession = useCallback(() => {
-    setSessionId(crypto.randomUUID());
+  const resetSession = useCallback((projectId?: string) => {
+    const { user } = useAuthStore.getState();
+    if (projectId && user?.id) {
+      // 프로젝트 기반 세션으로 리셋
+      setSessionId(`${user.id}-${projectId}`);
+    } else {
+      setSessionId(null);
+    }
     setMessages([]);
     setAnalyzing(false);
     setAnalysisComplete(false);
+  }, []);
+
+  /**
+   * 히스토리 로드 - 페이지 진입 시 호출
+   */
+  const loadHistory = useCallback(async (projectId: string) => {
+    const { user } = useAuthStore.getState();
+    if (!user?.id) return;
+
+    const sid = `${user.id}-${projectId}`;
+    setSessionId(sid);
+
+    try {
+      const res = await fetch(`${CHAT_API_URL}/chat/history/${sid}?limit=20`, {
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const loadedMessages: ChatMessage[] = data.messages.map(
+          (m: { role: string; content: string }, i: number) => ({
+            id: `loaded-${i}`,
+            role: m.role === "ai" ? "assistant" : "user",
+            content: m.content,
+            timestamp: new Date(),
+          }),
+        );
+        setMessages(loadedMessages);
+      }
+    } catch (err) {
+      console.error("Failed to load chat history:", err);
+    }
   }, []);
 
   const clearAnalysisComplete = useCallback(() => {
@@ -257,9 +300,11 @@ export function useChatStream(options?: UseChatStreamOptions) {
     analysisComplete,
     currentResponse,
     currentSources,
+    sessionId,
     sendMessage,
     cancelStream,
     resetSession,
+    loadHistory,
     clearAnalysisComplete,
   };
 }


### PR DESCRIPTION
## 개요
챗봇 세션을 프로젝트 단위로 고정하여 새로고침해도 대화 기록이 유지되도록 개선합니다.
## 변경 사항
### [useChatStream.ts](cci:7://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/hooks/useChatStream.ts:0:0-0:0)
- 세션 ID 생성 방식 변경: `crypto.randomUUID()` → `userId-projectId` 형식
- `loadHistory(projectId)` 함수 추가: 페이지 진입 시 최근 20개 대화 기록 조회
- `resetSession(projectId?)` 수정: 프로젝트 기반 세션 리셋 지원
### [AIAssistantPanel.tsx](cci:7://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/components/editor/AIAssistantPanel.tsx:0:0-0:0)
- `useEffect`로 페이지 진입 시 `loadHistory` 자동 호출
- 리셋 버튼에 `projectId` 전달
## 테스트 방법
1. 챗봇에서 대화 진행
2. 페이지 새로고침
3. 이전 대화 기록이 유지되는지 확인
4. 다른 프로젝트로 이동 시 다른 히스토리가 표시되는지 확인
## 관련 PR
- Backend: `feature/chat-log-storage` 브랜치의 히스토리 조회 API 추가 필요