### PR TITLE
hotfix: 400 에러(쿠키 없음) 발생 시 인증 초기화 무한 루프 수정

### DIFF
--- a/src/hooks/useAuthInit.ts
+++ b/src/hooks/useAuthInit.ts
@@ -34,8 +34,16 @@ export function useAuthInit() {
           await authService.refresh();
           const userResponse = await authService.getMe();
           setUser(userResponse.data);
-        } catch {
-          // refresh도 실패하면 로그아웃 상태 유지 (조용히)
+        } catch (error) {
+          // 400 에러(쿠키 없음)인 경우 즉시 중단하고 초기화 완료 처리
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((error as any).response?.status === 400) {
+            console.log("[AuthInit] No refresh token (400). Stopping init.");
+            logout();
+            setIsInitializing(false);
+            return;
+          }
+          // 그 외 실패 시에도 로그아웃
           logout();
         }
       } finally {


### PR DESCRIPTION
## 🔧 작업 내용
- [useAuthInit.ts](cci:7://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/hooks/useAuthInit.ts:0:0-0:0)에서 `authService.refresh()` 호출이 400 Bad Request(토큰 없음)로 실패할 경우, 즉시 로그아웃 처리하고 초기화를 중단하도록 수정했습니다.
## 🐛 문제 상황
- 배포 환경에서 첫 접속 시(또는 쿠키 유실 시) [refresh](cci:1://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/back/stolink_spring/src/main/java/com/stolink/backend/domain/user/controller/AuthController.java:66:4-91:5) 요청이 400 에러를 반환합니다.
- 기존 로직은 400 에러 발생 시에도 초기화 상태를 명확히 종료하지 않아, 리다이렉트나 리렌더링에 의해 다시 [initAuth](cci:1://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/hooks/useAuthInit.ts:25:4-51:6)가 호출되는 무한 루프(Infinite Loop)가 발생했습니다.
- 이로 인해 `Initializing...` 화면에서 멈추거나 지속적인 네트워크 요청이 발생했습니다.
## 💡 해결 방법
- `catch` 블록에서 `error.response.status === 400`을 감지하여, 이 경우 `setIsInitializing(false)`를 명시적으로 호출하고 함수를 `return`하여 루프를 확실하게 차단했습니다.
## ✅ 영향 범위
- 인증 초기화 로직 ([useAuthInit](cci:1://file:///Users/namhyeonseo/Krafton_Jungle/Sto-link/front/stolink_frontend/src/hooks/useAuthInit.ts:4:0-57:1))
- 비로그인 사용자 및 토큰 만료 사용자 접속 시나리오