### PR TITLE
fix(graph): CanvasGraph 노드 undefined 타입 에러 수정 (Hotfix)

### DIFF
--- a/src/components/CharacterGraph/CanvasGraph/index.tsx
+++ b/src/components/CharacterGraph/CanvasGraph/index.tsx
@@ -416,13 +416,13 @@ export const CharacterGraphCanvas = forwardRef<
 
         // Find fresh character objects from map (Ensures full data)
         const sourceId =
-          typeof link.source === "object"
+          typeof link.source === "object" && link.source
             ? (link.source as CharacterNode).id
-            : link.source;
+            : String(link.source);
         const targetId =
-          typeof link.target === "object"
+          typeof link.target === "object" && link.target
             ? (link.target as CharacterNode).id
-            : link.target;
+            : String(link.target);
 
         const sourceChar = characterMap.get(sourceId);
         const targetChar = characterMap.get(targetId);


### PR DESCRIPTION
## 📋 변경 사항

CanvasGraph에서 노드 데이터 접근 시 발생하던 TS18048 에러를 수정했습니다.
Release 브랜치 기반으로 Clean Hotfix를 다시 생성했습니다.
이전 PR의 충돌 문제를 해결하기 위해 dev 변경사항이 섞이지 않은 순수 hotfix 브랜치입니다.

## 📁 변경된 파일

- src/components/CharacterGraph/CanvasGraph/index.tsx

## ✅ 체크리스트

- [x] 빌드 성공 확인 (npm run build)
- [x] 타입 체크 통과 (npm run type-check)