### PR TITLE
fix(graph): resolve remaining undefined node errors in CanvasGraph (Final Hotfix)

### DIFF
--- a/src/components/CharacterGraph/CanvasGraph/index.tsx
+++ b/src/components/CharacterGraph/CanvasGraph/index.tsx
@@ -416,13 +416,13 @@ export const CharacterGraphCanvas = forwardRef<
 
         // Find fresh character objects from map (Ensures full data)
         const sourceId =
-          typeof link.source === "object"
+          typeof link.source === "object" && link.source
             ? (link.source as CharacterNode).id
-            : link.source;
+            : String(link.source);
         const targetId =
-          typeof link.target === "object"
+          typeof link.target === "object" && link.target
             ? (link.target as CharacterNode).id
-            : link.target;
+            : String(link.target);
 
         const sourceChar = characterMap.get(sourceId);
         const targetChar = characterMap.get(targetId);

--- a/src/components/CharacterGraph/CanvasGraph/index.tsx
+++ b/src/components/CharacterGraph/CanvasGraph/index.tsx
@@ -205,13 +205,13 @@ export const CharacterGraphCanvas = forwardRef<
         const adj = new Map<string, string[]>();
         links.forEach((l) => {
           const s =
-            typeof l.source === "object"
+            typeof l.source === "object" && l.source
               ? (l.source as CharacterNode).id
-              : l.source;
+              : String(l.source);
           const t =
-            typeof l.target === "object"
+            typeof l.target === "object" && l.target
               ? (l.target as CharacterNode).id
-              : l.target;
+              : String(l.target);
           if (!adj.has(s)) adj.set(s, []);
           if (!adj.has(t)) adj.set(t, []);
           adj.get(s)?.push(t);
@@ -241,13 +241,13 @@ export const CharacterGraphCanvas = forwardRef<
         // Assign depth to links and Fix Direction (Source -> Target = Low Depth -> High Depth)
         links.forEach((l) => {
           const sId =
-            typeof l.source === "object"
+            typeof l.source === "object" && l.source
               ? (l.source as CharacterNode).id
-              : l.source;
+              : String(l.source);
           const tId =
-            typeof l.target === "object"
+            typeof l.target === "object" && l.target
               ? (l.target as CharacterNode).id
-              : l.target;
+              : String(l.target);
 
           const sDepth = nodeDepths.get(sId);
           const tDepth = nodeDepths.get(tId);
@@ -277,13 +277,13 @@ export const CharacterGraphCanvas = forwardRef<
 
       links.forEach((link) => {
         const s =
-          typeof link.source === "object"
+          typeof link.source === "object" && link.source
             ? (link.source as CharacterNode).id
-            : link.source;
+            : String(link.source);
         const t =
-          typeof link.target === "object"
+          typeof link.target === "object" && link.target
             ? (link.target as CharacterNode).id
-            : link.target;
+            : String(link.target);
         const key = [s, t].sort().join("-");
         if (!pairMap.has(key)) pairMap.set(key, []);
         pairMap.get(key)!.push(link);
@@ -317,9 +317,9 @@ export const CharacterGraphCanvas = forwardRef<
         // [Bidirectional Detection]
         const groupSources = new Set(
           group.map((l) =>
-            typeof l.source === "object"
+            typeof l.source === "object" && l.source
               ? (l.source as CharacterNode).id
-              : l.source,
+              : String(l.source),
           ),
         );
         const isReciprocal = groupSources.size > 1;
@@ -1006,22 +1006,26 @@ export const CharacterGraphCanvas = forwardRef<
           <RelationshipEventTooltip
             events={hoveredLink.link.history || []}
             sourceName={
-              typeof hoveredLink.link.source === "object"
+              typeof hoveredLink.link.source === "object" &&
+              hoveredLink.link.source
                 ? (hoveredLink.link.source as CharacterNode).name
                 : "Unknown"
             }
             targetName={
-              typeof hoveredLink.link.target === "object"
+              typeof hoveredLink.link.target === "object" &&
+              hoveredLink.link.target
                 ? (hoveredLink.link.target as CharacterNode).name
                 : "Unknown"
             }
             sourceImage={
-              typeof hoveredLink.link.source === "object"
+              typeof hoveredLink.link.source === "object" &&
+              hoveredLink.link.source
                 ? (hoveredLink.link.source as CharacterNode).imageUrl
                 : undefined
             }
             targetImage={
-              typeof hoveredLink.link.target === "object"
+              typeof hoveredLink.link.target === "object" &&
+              hoveredLink.link.target
                 ? (hoveredLink.link.target as CharacterNode).imageUrl
                 : undefined
             }
@@ -1032,11 +1036,13 @@ export const CharacterGraphCanvas = forwardRef<
             description={hoveredLink.link.description}
             onEventClick={(event) => {
               const source =
-                typeof hoveredLink.link.source === "object"
+                typeof hoveredLink.link.source === "object" &&
+                hoveredLink.link.source
                   ? (hoveredLink.link.source as CharacterNode)
                   : { name: "Unknown" };
               const target =
-                typeof hoveredLink.link.target === "object"
+                typeof hoveredLink.link.target === "object" &&
+                hoveredLink.link.target
                   ? (hoveredLink.link.target as CharacterNode)
                   : { name: "Unknown" };
 


### PR DESCRIPTION
## 📋 변경 사항

이전 핫픽스(#181) 머지 이후 발생할 수 있는 잔여 TS18048 에러를 해결하기 위한 추가 핫픽스입니다.
 계산 로직, BFS 탐색, 툴팁 렌더링 등  내의 모든 불확실한 노드 접근 지점에 방어 코드(null check)를 적용했습니다.

**주요 수정:**
-  및  접근 시  체크 추가
-  props 전달 시 안전한 형변환 적용

## 📁 변경된 파일

- src/components/CharacterGraph/CanvasGraph/index.tsx

## ✅ 체크리스트

- [x] 빌드 성공 확인 (npm run build)
- [x] 타입 체크 통과 (npm run type-check)