### PR TITLE
fix(proxy): 챗봇 API 경로 불일치 해결을 위한 프록시 설정 수정

### DIFF
--- a/src/hooks/useAuthInit.ts
+++ b/src/hooks/useAuthInit.ts
@@ -34,8 +34,16 @@ export function useAuthInit() {
           await authService.refresh();
           const userResponse = await authService.getMe();
           setUser(userResponse.data);
-        } catch {
-          // refresh도 실패하면 로그아웃 상태 유지 (조용히)
+        } catch (error) {
+          // 400 에러(쿠키 없음)인 경우 즉시 중단하고 초기화 완료 처리
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((error as any).response?.status === 400) {
+            console.log("[AuthInit] No refresh token (400). Stopping init.");
+            logout();
+            setIsInitializing(false);
+            return;
+          }
+          // 그 외 실패 시에도 로그아웃
           logout();
         }
       } finally {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       "/ai-api": {
         target: "http://localhost:8000",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ai-api/, "/api"),
+
         secure: false,
       },
       // MinIO Buckets Proxy


### PR DESCRIPTION
## 📌 개요
로그인 시 발생하는 무한 로딩 이슈를 해결하고, 배포 환경과의 정합성을 위해 챗봇 API의 로컬 프록시 설정을 수정했습니다.
## 🛠️ 변경사항
### 1. 인증/로그인 (Auth)
- 로그인 실패 또는 리프레시 토큰 만료 시 무한 로딩이 발생하는 문제를 수정했습니다.
- (`여기에 로그인 관련 구체적 수정 사항 한 줄 추가하면 좋습니다`)
### 2. 챗봇 API (Chatbot)
- **vite.config.ts**: `/ai-api` 경로에 대한 Proxy `rewrite` 규칙을 제거했습니다.
  - **AS-IS**: `/ai-api` 요청을 `/api`로 변환하여 백엔드로 전송
  - **TO-BE**: `/ai-api` 경로 그대로 전송 (백엔드 라우터 경로 통일)
## 💡 배경
배포된 CloudFront 환경에서는 `/ai-api` 경로가 그대로 백엔드로 전달되나, 로컬에서는 `/api`로 변환되어 경로 불일치(404)가 발생했습니다. 백엔드 설정을 `/ai-api`로 표준화함에 따라 프론트엔드 설정을 동기화했습니다.
## ✅ 테스트 계획
- [ ] 로그인/로그아웃 시 정상적으로 페이지가 이동하는지 확인
- [ ] 챗봇 질의 시 404 에러 없이 스트리밍 응답이 오는지 확인