### PR TITLE
fix(chat): 챗봇 스트림 API 경로를 /stream (Dev 표준)으로 변경

### DIFF
--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -107,8 +107,8 @@ export function useChatStream(options?: UseChatStreamOptions) {
           Accept: "text/event-stream",
         };
 
-        // Corrected path from /ai/chat/stream to /chat/stream as per guide
-        const response = await fetch(`${CHAT_API_URL}/chat/stream`, {
+        // Chat stream endpoint: /ai-api/stream
+        const response = await fetch(`${CHAT_API_URL}/stream`, {
           method: "POST",
           headers,
           body: JSON.stringify({


### PR DESCRIPTION
## 📌 개요
Release 환경의 백엔드 API 라우팅이 Dev 표준(`/ai-api` prefix)으로 롤백됨에 따라, 프론트엔드 API 호출 경로도 이에 맞춰 동기화했습니다.
## 🛠️ 변경사항
- **src/hooks/useChatStream.ts**:
  - `fetch` 요청 경로를 `/ai-api/chat/stream`에서 **`/ai-api/stream`**으로 변경했습니다.
## 💡 배경
현재 인프라 및 Dev 환경과의 호환성을 위해 백엔드 라우터를 `/ai-api/stream`으로 롤백했습니다. 이에 맞춰 프론트엔드도 동일한 경로를 바라보도록 수정하여 404 에러를 방지했습니다.
## ✅ 체크리스트
- [ ] 로컬 개발 서버(`npm run dev`) 및 백엔드(`uvicorn`) 실행 시 챗봇 메시지 전송 정상 동작 확인