### PR TITLE
fix: history 주석 처리 활성화

### DIFF
--- a/src/components/editor/AIAssistantPanel.tsx
+++ b/src/components/editor/AIAssistantPanel.tsx
@@ -39,6 +39,7 @@ export default function AIAssistantPanel({ projectId }: AIAssistantPanelProps) {
     sendMessage,
     cancelStream,
     resetSession,
+    loadHistory,
     clearAnalysisComplete,
   } = useChatStream({
     onError: (error) => {
@@ -47,11 +48,11 @@ export default function AIAssistantPanel({ projectId }: AIAssistantPanelProps) {
   });
 
   // 페이지 진입 시 히스토리 로드
-  // useEffect(() => {
-  //   if (projectId) {
-  //     loadHistory(projectId);
-  //   }
-  // }, [projectId, loadHistory]);
+  useEffect(() => {
+    if (projectId) {
+      loadHistory(projectId);
+    }
+  }, [projectId, loadHistory]);
 
   // 분석 완료 애니메이션 표시 상태
   const [showCompleteAnimation, setShowCompleteAnimation] = useState(false);


### PR DESCRIPTION
## 📋 Summary
dev 환경에서 챗봇 대화 내용이 표시되지 않는 문제를 해결합니다.

## 🔍 Problem
API 경로 불일치: 프론트엔드가 /ai-api/chat/history, /ai-api/chat/stop으로 요청하지만, 백엔드는 /ai-api/history, /ai-api/stop을 기대함
loadHistory 미호출: #170 커밋에서 빌드 에러 수정 중 loadHistory() 호출 코드가 주석 처리됨
## ✅ Changes
`src/components/editor/AIAssistantPanel.tsx`
useChatStream()
에서 loadHistory destructuring 추가
페이지 진입 시 loadHistory(projectId) 호출하는 useEffect 활성화
## 🧪 Test
 로컬 환경에서 챗봇 대화 후 새로고침 시 기록 로드 확인
 dev 환경 배포 후 동작 확인 필요
