### PR TITLE
fix(editor): Prevent content saved to wrong document during rapid navigation

### DIFF
--- a/src/pages/editor/hooks/useEditorHandlers.ts
+++ b/src/pages/editor/hooks/useEditorHandlers.ts
@@ -64,7 +64,10 @@ export function useEditorHandlers({
   const wordCountTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const lastContentRef = useRef<string>("");
+  const lastContentRef = useRef<{
+    documentId: string | null;
+    content: string;
+  }>({ documentId: null, content: "" });
   const saveContentRef = useRef(saveContent);
   const selectedSectionIdRef = useRef(selectedSectionId);
 
@@ -102,16 +105,20 @@ export function useEditorHandlers({
 
   // Force save current content
   const forceSave = useCallback(async () => {
-    if (isDemo || !selectedSectionIdRef.current) return;
+    if (isDemo) return;
 
+    // Cancel any pending auto-save timer
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = null;
     }
 
-    if (lastContentRef.current && saveContentRef.current) {
+    // Save using the stored document ID (not current selection)
+    const { documentId, content } = lastContentRef.current;
+    if (documentId && content && saveContentRef.current) {
       try {
-        await saveContentRef.current(lastContentRef.current);
+        await saveContentRef.current(content);
+        console.log(`[forceSave] Saved content for document: ${documentId}`);
       } catch (error) {
         console.error("[EditorPage] Force save failed:", error);
       }
@@ -184,7 +191,17 @@ export function useEditorHandlers({
   const handleSelectSection = useCallback(
     async (id: string) => {
       if (selectedSectionId !== id) {
+        // Cancel any pending auto-save timer before switching
+        if (saveTimeoutRef.current) {
+          clearTimeout(saveTimeoutRef.current);
+          saveTimeoutRef.current = null;
+        }
+
+        // Force save content to the ORIGINAL document (not new selection)
         await forceSave();
+
+        // Reset content ref for new document
+        lastContentRef.current = { documentId: null, content: "" };
       }
       setSelectedSectionId(id);
     },
@@ -194,7 +211,13 @@ export function useEditorHandlers({
   // Content change with debounce
   const handleContentChange = useCallback(
     (content: string) => {
-      lastContentRef.current = content;
+      // Store both document ID and content together
+      const currentDocId = selectedSectionIdRef.current;
+      lastContentRef.current = {
+        documentId: currentDocId,
+        content: content,
+      };
+
       if (isDemo) return;
 
       // 🔴 Fix: ref를 통해 setSaveStatus 호출 (React 렌더링 사이클 호환)
@@ -205,6 +228,17 @@ export function useEditorHandlers({
       }
 
       saveTimeoutRef.current = setTimeout(async () => {
+        // Validate: only save if still on the same document
+        const savedDocId = lastContentRef.current.documentId;
+        const nowDocId = selectedSectionIdRef.current;
+
+        if (savedDocId !== nowDocId) {
+          console.log(
+            `[Auto-save] Cancelled: Document changed from ${savedDocId} to ${nowDocId}`,
+          );
+          return; // Don't save to wrong document!
+        }
+
         setSaveStatusRef.current("saving");
         try {
           await saveContentRef.current(content);
@@ -268,6 +302,11 @@ export function useEditorHandlers({
 
       // 1. 섹션 전환 전 현재 콘텐츠 저장 (데이터 손실 방지)
       try {
+        // Cancel any pending timer and force save immediately
+        if (saveTimeoutRef.current) {
+          clearTimeout(saveTimeoutRef.current);
+          saveTimeoutRef.current = null;
+        }
         await forceSave();
       } catch (error) {
         console.error(
@@ -298,7 +337,7 @@ export function useEditorHandlers({
       });
       if (newDoc) {
         // 2. 새 문서 전환 시 lastContentRef 초기화 (이전 콘텐츠 오염 방지)
-        lastContentRef.current = "";
+        lastContentRef.current = { documentId: null, content: "" };
         setSelectedSectionId(newDoc.id);
       }
       return newDoc;

--- a/src/pages/editor/hooks/useKeyboardSave.ts
+++ b/src/pages/editor/hooks/useKeyboardSave.ts
@@ -4,7 +4,10 @@ interface UseKeyboardSaveOptions {
   isDemo: boolean;
   selectedSectionId: string | null;
   saveContentRef: React.RefObject<(content: string) => Promise<void>>;
-  lastContentRef: React.RefObject<string>;
+  lastContentRef: React.RefObject<{
+    documentId: string | null;
+    content: string;
+  }>;
   saveTimeoutRef: React.RefObject<ReturnType<typeof setTimeout> | null>;
   getLatestContent?: () => string;
 }
@@ -34,7 +37,7 @@ export function useKeyboardSave({
             // Get content from callback if available (for debounced editors), otherwise use ref
             const contentToSave = getLatestContent
               ? getLatestContent()
-              : lastContentRef.current || "";
+              : lastContentRef.current?.content || "";
 
             // If content is empty strings, we should still save if that's the intention,
             // but usually we want to fallback to lastContentRef if getContent returns empty?


### PR DESCRIPTION
🐛 Problem
빠르게 챕터를 전환할 때 내용이 잘못된 문서에 저장되는 버그

재현:

챕터1에서 타이핑
0.5초 이내에 챕터2로 전환
결과: 챕터1 내용이 챕터2에 저장됨 ❌
원인: Race Condition

lastContentRef는 내용만 저장 (어느 문서 것인지 모름)
자동 저장 타이머가 실행될 때 selectedSectionId가 이미 변경됨
✅ Solution
핵심 변경
Document ID를 content와 함께 저장
typescript
lastContentRef = { documentId: "chapter-1", content: "..." }
저장 시 Document ID 검증
typescript
if (savedDocId !== nowDocId) {
  return; // 다른 문서로 이동했으면 저장 취소
}
문서 전환 시 타이머 즉시 취소
