### PR TITLE
fix(world): 분석 완료 연출 및 모달 미노출 이슈 수정 (상태 영속성 도입)

### DIFF
--- a/src/components/CharacterGraph/CanvasGraph/index.tsx
+++ b/src/components/CharacterGraph/CanvasGraph/index.tsx
@@ -124,27 +124,14 @@ export const CharacterGraphCanvas = forwardRef<
     // 이미지 캐싱
     const imageCache = useImageCache(characters);
 
-    // [DEBUG] highlightedNodeIds 변경 감지
-    useEffect(() => {
-      console.log(
-        "[DEBUG CanvasGraph] highlightedNodeIds changed:",
-        highlightedNodeIds,
-      );
-    }, [highlightedNodeIds]);
+    // [DEBUG] highlightedNodeIds 변경 감지 (Disabled)
 
-    // [DEBUG] selectedNodeId 변경 감지
-    useEffect(() => {
-      console.log(
-        "[DEBUG CanvasGraph] selectedNodeId changed:",
-        selectedNodeId,
-      );
-    }, [selectedNodeId]);
+    // [DEBUG] selectedNodeId 변경 감지 (Disabled)
 
     // ESC 키 핸들러: 선택 해제 및 전체 뷰 복원
     useEffect(() => {
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
-          console.log("[DEBUG CanvasGraph] ESC pressed, resetting view");
           // 전체 뷰로 줌 아웃
           if (graphRef.current) {
             graphRef.current.zoomToFit(400, 80);
@@ -459,11 +446,6 @@ export const CharacterGraphCanvas = forwardRef<
         const targetChar = characterMap.get(targetId);
 
         if (!sourceChar || !targetChar) {
-          console.warn(
-            "[DeepAnalysis] Character lookup failed for:",
-            sourceId,
-            targetId,
-          );
           return;
         }
 
@@ -499,8 +481,8 @@ export const CharacterGraphCanvas = forwardRef<
           );
           setDeepAnalysisData(analysisData);
           setHoveredLink(null); // Close tooltip
-        } catch (error) {
-          console.error("[DeepAnalysis] Generation failed:", error);
+        } catch (_error) {
+          // ignore
         }
       },
       [onLinkClick, events, characterMap],
@@ -534,11 +516,6 @@ export const CharacterGraphCanvas = forwardRef<
 
     // 안정적인 검색 콜백 (ref를 통해 최신 함수 호출)
     const handleSearchChange = useCallback((matchingIds: string[] | null) => {
-      console.log("[DEBUG] handleSearchChange called:", matchingIds);
-      console.log(
-        "[DEBUG] onSearchChangeRef.current:",
-        onSearchChangeRef.current,
-      );
       onSearchChangeRef.current?.(matchingIds);
     }, []);
 
@@ -986,17 +963,9 @@ export const CharacterGraphCanvas = forwardRef<
           <CharacterSearchOverlay
             characters={characters}
             onSelect={(character) => {
-              console.log(
-                "[DEBUG] onSelect called:",
-                character.profile?.name,
-                character._id,
-              );
-
               // graphDataRef에서 시뮬레이션이 업데이트한 노드 좌표 가져오기
               const graphNodes = graphDataRef.current.nodes as CharacterNode[];
-              console.log("[DEBUG] graphNodes count:", graphNodes.length);
               const node = graphNodes.find((n) => n.id === character._id);
-              console.log("[DEBUG] found node:", node);
 
               if (
                 graphRef.current &&

--- a/src/components/CharacterGraph/CanvasGraph/index.tsx
+++ b/src/components/CharacterGraph/CanvasGraph/index.tsx
@@ -124,6 +124,38 @@ export const CharacterGraphCanvas = forwardRef<
     // 이미지 캐싱
     const imageCache = useImageCache(characters);
 
+    // [DEBUG] highlightedNodeIds 변경 감지
+    useEffect(() => {
+      console.log(
+        "[DEBUG CanvasGraph] highlightedNodeIds changed:",
+        highlightedNodeIds,
+      );
+    }, [highlightedNodeIds]);
+
+    // [DEBUG] selectedNodeId 변경 감지
+    useEffect(() => {
+      console.log(
+        "[DEBUG CanvasGraph] selectedNodeId changed:",
+        selectedNodeId,
+      );
+    }, [selectedNodeId]);
+
+    // ESC 키 핸들러: 선택 해제 및 전체 뷰 복원
+    useEffect(() => {
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          console.log("[DEBUG CanvasGraph] ESC pressed, resetting view");
+          // 전체 뷰로 줌 아웃
+          if (graphRef.current) {
+            graphRef.current.zoomToFit(400, 80);
+          }
+          // 선택 해제는 부모(WorldPage)에서 처리
+        }
+      };
+      window.addEventListener("keydown", handleKeyDown);
+      return () => window.removeEventListener("keydown", handleKeyDown);
+    }, []);
+
     // Animation Loop
     useEffect(() => {
       let frameId: number;
@@ -163,23 +195,7 @@ export const CharacterGraphCanvas = forwardRef<
       });
     }, [characters, initialLinks]);
 
-    // Ref 핸들 설정 (initialNodes 이후에 선언)
-    useImperativeHandle(
-      ref,
-      () => ({
-        focusNode: async (nodeId: string) => {
-          // react-force-graph-2d의 줌 기능으로 특정 노드 포커스
-          if (graphRef.current) {
-            const node = initialNodes.find((n) => n.id === nodeId);
-            if (node && node.x !== undefined && node.y !== undefined) {
-              graphRef.current.centerAt(node.x, node.y, 1000);
-              graphRef.current.zoom(2, 1000);
-            }
-          }
-        },
-      }),
-      [initialNodes],
-    );
+    // NOTE: useImperativeHandle moved after graphDataRef declaration
 
     // [Curvature Fix] BFS for Flow Depth & Universal Curvature + 4D Timeline Filtering
     const processedLinks = useMemo(() => {
@@ -386,6 +402,35 @@ export const CharacterGraphCanvas = forwardRef<
       [initialNodes, processedLinks],
     ) as ForceGraphData;
 
+    // graphData 참조 유지 (시뮬레이션이 in-place로 수정한 노드 좌표 접근용)
+    const graphDataRef = useRef(graphData);
+    useEffect(() => {
+      graphDataRef.current = graphData;
+    }, [graphData]);
+
+    // Ref 핸들 설정 (graphDataRef 이후에 선언해야 시뮬레이션된 좌표 접근 가능)
+    useImperativeHandle(
+      ref,
+      () => ({
+        focusNode: async (nodeId: string) => {
+          // graphDataRef에서 시뮬레이션이 업데이트한 노드 좌표 가져오기
+          const graphNodes = graphDataRef.current.nodes as CharacterNode[];
+          const node = graphNodes.find((n) => n.id === nodeId);
+
+          if (
+            graphRef.current &&
+            node &&
+            node.x !== undefined &&
+            node.y !== undefined
+          ) {
+            graphRef.current.centerAt(node.x, node.y, 1000);
+            graphRef.current.zoom(2, 1000);
+          }
+        },
+      }),
+      [], // 빈 의존성 - ref를 통해 최신 데이터 접근
+    );
+
     // Character ID → Character 매핑
     const characterMap = useMemo(() => {
       const map = new Map<string, Character>();
@@ -486,6 +531,16 @@ export const CharacterGraphCanvas = forwardRef<
     useEffect(() => {
       onSearchChangeRef.current = onSearchChange;
     }, [onSearchChange]);
+
+    // 안정적인 검색 콜백 (ref를 통해 최신 함수 호출)
+    const handleSearchChange = useCallback((matchingIds: string[] | null) => {
+      console.log("[DEBUG] handleSearchChange called:", matchingIds);
+      console.log(
+        "[DEBUG] onSearchChangeRef.current:",
+        onSearchChangeRef.current,
+      );
+      onSearchChangeRef.current?.(matchingIds);
+    }, []);
 
     // 노드 클릭 핸들러 (Ref 패턴으로 안정화)
     const handleNodeClick = useCallback(
@@ -931,12 +986,35 @@ export const CharacterGraphCanvas = forwardRef<
           <CharacterSearchOverlay
             characters={characters}
             onSelect={(character) => {
-              const node = initialNodes.find((n) => n.id === character._id);
-              if (node && onNodeClick) {
+              console.log(
+                "[DEBUG] onSelect called:",
+                character.profile?.name,
+                character._id,
+              );
+
+              // graphDataRef에서 시뮬레이션이 업데이트한 노드 좌표 가져오기
+              const graphNodes = graphDataRef.current.nodes as CharacterNode[];
+              console.log("[DEBUG] graphNodes count:", graphNodes.length);
+              const node = graphNodes.find((n) => n.id === character._id);
+              console.log("[DEBUG] found node:", node);
+
+              if (
+                graphRef.current &&
+                node &&
+                node.x !== undefined &&
+                node.y !== undefined
+              ) {
+                // 부드러운 줌 애니메이션 (1200ms로 천천히)
+                graphRef.current.centerAt(node.x, node.y, 1200);
+                graphRef.current.zoom(1.3, 1200);
+              }
+
+              // 노드 선택 콜백 호출
+              if (onNodeClick) {
                 onNodeClick(character);
               }
             }}
-            onSearch={onSearchChange || (() => {})}
+            onSearch={handleSearchChange}
           />
         )}
 

--- a/src/components/CharacterGraph/CanvasGraph/useSemanticForce.ts
+++ b/src/components/CharacterGraph/CanvasGraph/useSemanticForce.ts
@@ -96,26 +96,27 @@ export function useSemanticForce(
 
             if (isSourceFocus || isTargetFocus) {
               // Hero와 직접 연결된 노드는 가까이 (위성 궤도)
-              return 200;
+              return 180;
             }
-            return 2000; // 나머지는 멀리
+            return 1500; // 나머지는 멀리 (2000→1500)
           }
 
           // Type-based Distance (관계 타입에 따른 거리만 적용)
           const weight = getRelationWeight(link.type as string, link.strength);
 
           // 인력(양수) = 가까이, 척력(음수) = 멀리
+          // 범위를 좁혀서 극단적 뭉침/흩어짐 방지
           if (weight > 0) {
-            // 인력: 기본 거리에서 줄임
+            // 인력: 기본 거리에서 줄임 (최소 110px로 상향)
             return Math.max(
-              80,
+              110, // 80→110: 최소 거리 상향으로 뭉침 방지
               FORCE_CONFIG.linkDistance -
                 weight * SEMANTIC_FORCE_CONFIG.attractionDistance,
             );
           } else {
-            // 척력: 기본 거리에서 늘림
+            // 척력: 기본 거리에서 늘림 (최대 250px로 하향)
             return Math.min(
-              400,
+              250, // 400→250: 최대 거리 하향으로 과도한 분리 방지
               FORCE_CONFIG.linkDistance +
                 Math.abs(weight) * SEMANTIC_FORCE_CONFIG.repulsionDistance,
             );
@@ -129,18 +130,21 @@ export function useSemanticForce(
           if (layoutMode === "focus" && focusTargetId) {
             const isSourceFocus = source.id === focusTargetId;
             const isTargetFocus = target.id === focusTargetId;
-            if (isSourceFocus || isTargetFocus) return 0.8; // Stronger link attraction
+            if (isSourceFocus || isTargetFocus) return 0.6; // 0.8→0.6: Focus 모드 인력 완화
             return 0; // Hide others links basically
           }
 
           // Link strength: 관계 타입에 따라서만 결정
           const weight = getRelationWeight(link.type as string, link.strength);
 
-          // 인력은 weight에 비례, 척력은 약하게
+          // 인력/척력 모두 균일하게 적당한 강도 유지
+          // 극단적 차이 없이 안정적인 레이아웃
           if (weight > 0) {
-            return FORCE_CONFIG.linkStrength * (1 + weight * 0.5);
+            // 인력: 약간 강하게 (0.3 ~ 0.45 범위)
+            return FORCE_CONFIG.linkStrength * (1 + weight * 0.25); // 0.5→0.25: 배율 완화
           } else {
-            return FORCE_CONFIG.linkStrength * 0.3;
+            // 척력: 비슷한 강도로 (분리된 위치 유지)
+            return FORCE_CONFIG.linkStrength * 0.4; // 0.3→0.4: 척력 링크도 적당한 강도
           }
         });
     }
@@ -207,7 +211,7 @@ export function useSemanticForce(
     });
 
     // D3 Disjoint Pattern: forceX & forceY
-    // 각 노드를 해당 그룹의 중심으로 약하게 당김
+    // 각 노드를 해당 그룹의 중심으로 당기되, 관계 없는 노드는 전체 중앙으로 더 강하게 모음
     const forceXConfig = d3
       .forceX<CharacterNode>()
       .x((node) => {
@@ -215,9 +219,28 @@ export function useSemanticForce(
           return node.id === focusTargetId ? 0 : node.x || 0;
         }
         const center = groupCenters.get(node.group || "");
+        // 그룹이 있으면 그룹 중심, 없으면 전체 중앙(0,0)
         return center ? center.x : 0;
       })
-      .strength(0.05); // 매우 약한 인력 (위치 가이드만)
+      .strength((node) => {
+        if (layoutMode === "focus" && focusTargetId) {
+          return 0.01;
+        }
+        // 관계 수가 적을수록 중앙으로 더 강하게 끌림
+        const relationCount = node.relationCount || 0;
+        const hasGroup = node.group && node.group !== "무소속";
+
+        if (relationCount === 0) {
+          // 관계 없는 노드: 중앙으로 강하게 (0.15)
+          return 0.15;
+        } else if (!hasGroup) {
+          // 그룹 없는 노드: 중앙으로 중간 강도 (0.12)
+          return 0.12;
+        } else {
+          // 그룹 있는 노드: 그룹 중심으로 약하게 (0.08)
+          return 0.08;
+        }
+      });
 
     const forceYConfig = d3
       .forceY<CharacterNode>()
@@ -228,7 +251,21 @@ export function useSemanticForce(
         const center = groupCenters.get(node.group || "");
         return center ? center.y : 0;
       })
-      .strength(0.05); // 매우 약한 인력 (위치 가이드만)
+      .strength((node) => {
+        if (layoutMode === "focus" && focusTargetId) {
+          return 0.01;
+        }
+        const relationCount = node.relationCount || 0;
+        const hasGroup = node.group && node.group !== "무소속";
+
+        if (relationCount === 0) {
+          return 0.15;
+        } else if (!hasGroup) {
+          return 0.12;
+        } else {
+          return 0.08;
+        }
+      });
 
     fg.d3Force("x", forceXConfig);
     fg.d3Force("y", forceYConfig);

--- a/src/components/CharacterGraph/CharacterSearchOverlay.tsx
+++ b/src/components/CharacterGraph/CharacterSearchOverlay.tsx
@@ -1,11 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useEffect,
-  useRef,
-  useDeferredValue,
-  useCallback,
-} from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Search, X } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -26,7 +19,7 @@ interface CharacterSearchOverlayProps {
  * 캐릭터 검색 오버레이 컴포넌트 (성능 최적화 버전)
  * - CSS Containment로 렌더링 격리
  * - Virtualization으로 DOM 노드 최소화 (590개 → ~10개)
- * - useDeferredValue로 입력 우선순위 분리
+ * - ref 패턴으로 콜백 안정화
  * - GPU 가속 transform 사용
  */
 export function CharacterSearchOverlay({
@@ -35,21 +28,26 @@ export function CharacterSearchOverlay({
   onSearch,
 }: CharacterSearchOverlayProps) {
   const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query); // 검색 결과 렌더링 우선순위 낮춤
   const [isFocused, setIsFocused] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const parentRef = useRef<HTMLDivElement>(null); // Virtualizer parent
 
-  // Search Logic with Fuzzy + Chosung (deferred query 사용)
+  // onSearch 콜백을 ref로 관리 (의존성 배열에서 제외하기 위함)
+  const onSearchRef = useRef(onSearch);
+  useEffect(() => {
+    onSearchRef.current = onSearch;
+  }, [onSearch]);
+
+  // Search Logic with Fuzzy + Chosung
   const matches = useMemo(() => {
-    if (!deferredQuery.trim()) return [];
+    if (!query.trim()) return [];
 
     return characters.filter((c) =>
-      matchesSearch(c.profile?.name || "", deferredQuery),
+      matchesSearch(c.profile?.name || "", query),
     );
-  }, [deferredQuery, characters]);
+  }, [query, characters]);
 
   // [Stability] Virtualizer 옵션 안정화 - 매 렌더링마다 재생성 방지
   const getScrollElement = useCallback(() => parentRef.current, []);
@@ -64,14 +62,27 @@ export function CharacterSearchOverlay({
     overscan: 5, // 버퍼 항목 수
   });
 
-  // Notify parent of matches for highlighting
+  // Notify parent of matches for highlighting (ref 패턴으로 안정화)
   useEffect(() => {
-    if (!deferredQuery.trim()) {
-      onSearch(null);
+    console.log(
+      "[DEBUG SearchOverlay] useEffect triggered, query:",
+      query,
+      "matches:",
+      matches.length,
+    );
+    console.log(
+      "[DEBUG SearchOverlay] onSearchRef.current:",
+      onSearchRef.current,
+    );
+    if (!query.trim()) {
+      console.log("[DEBUG SearchOverlay] calling onSearch(null)");
+      onSearchRef.current?.(null);
     } else {
-      onSearch(matches.map((c) => c._id));
+      const ids = matches.map((c) => c._id);
+      console.log("[DEBUG SearchOverlay] calling onSearch with ids:", ids);
+      onSearchRef.current?.(ids);
     }
-  }, [matches, deferredQuery, onSearch]);
+  }, [matches, query]);
 
   // Click outside handler
   useEffect(() => {
@@ -317,10 +328,10 @@ export function CharacterSearchOverlay({
                         >
                           {(() => {
                             const name = char.profile?.name || "이름 없음";
-                            if (!deferredQuery.trim()) return name;
+                            if (!query.trim()) return name;
 
                             try {
-                              const regex = getKoreanRegex(deferredQuery);
+                              const regex = getKoreanRegex(query);
                               const match = regex.exec(name);
                               if (!match) return name;
 

--- a/src/components/CharacterGraph/CharacterSearchOverlay.tsx
+++ b/src/components/CharacterGraph/CharacterSearchOverlay.tsx
@@ -64,22 +64,10 @@ export function CharacterSearchOverlay({
 
   // Notify parent of matches for highlighting (ref 패턴으로 안정화)
   useEffect(() => {
-    console.log(
-      "[DEBUG SearchOverlay] useEffect triggered, query:",
-      query,
-      "matches:",
-      matches.length,
-    );
-    console.log(
-      "[DEBUG SearchOverlay] onSearchRef.current:",
-      onSearchRef.current,
-    );
     if (!query.trim()) {
-      console.log("[DEBUG SearchOverlay] calling onSearch(null)");
       onSearchRef.current?.(null);
     } else {
       const ids = matches.map((c) => c._id);
-      console.log("[DEBUG SearchOverlay] calling onSearch with ids:", ids);
       onSearchRef.current?.(ids);
     }
   }, [matches, query]);

--- a/src/components/CharacterGraph/constants.ts
+++ b/src/components/CharacterGraph/constants.ts
@@ -305,19 +305,19 @@ export const MAX_CURVE_OFFSET = 60; // 곡선 제어점 최대 오프셋 (px)
 
 export const FORCE_CONFIG = {
   // 노드 간 반발력 (최적화: 거리 제한으로 연산 감소)
-  // Balanced repulsion (enough to separate, but not explode)
-  charge: -2500,
-  chargeDistanceMin: 100,
-  chargeDistanceMax: 4000,
+  // 완화된 척력: 노드들이 적당히 분리되면서도 너무 흩어지지 않음
+  charge: -1200, // -2500→-1200: 척력 대폭 완화
+  chargeDistanceMin: 80, // 100→80: 최소 거리 축소
+  chargeDistanceMax: 2500, // 4000→2500: 최대 영향 거리 축소
 
   // 링크 설정 (소프트 스프링)
   // Default breathing room
-  linkDistance: 150,
-  linkStrength: 0.3,
+  linkDistance: 160, // 150→160: 기본 거리 약간 증가
+  linkStrength: 0.35, // 0.3→0.35: 스프링 약간 강화
 
   // 센터링 (부드럽게)
-  centerStrength: 0.05, // Stronger centering to form a round shape (User Feedback)
-  positionStrength: 0.01,
+  centerStrength: 0.08, // 0.05→0.08: 중앙 집결력 강화
+  positionStrength: 0.02, // 0.01→0.02: 위치 유지력 강화
 
   // 충돌
   collisionPadding: 60,
@@ -325,52 +325,53 @@ export const FORCE_CONFIG = {
 
   // Dynamic Link Forces (Relationship-based)
   // STRATEGY:
-  // Friendly = Short & Rigid (Clump together)
-  // Hostile = Long & Strong (Force apart)
+  // Friendly = Moderate distance, soft spring (gentle clustering)
+  // Hostile = Moderate distance, weak spring (mild separation)
+  // Goal: Prevent extreme clumping or scattering
   dynamic: {
     ally: {
-      distance: 80,
-      strength: 0.9,
+      distance: 140, // 80→140: 뭉침 방지
+      strength: 0.4, // 0.9→0.4: 스프링 완화
     },
     mentor: {
-      distance: 90,
-      strength: 0.8,
+      distance: 150, // 90→150
+      strength: 0.35, // 0.8→0.35
     },
     protects: {
-      distance: 70,
-      strength: 0.9,
+      distance: 130, // 70→130
+      strength: 0.4, // 0.9→0.4
     },
     family: {
-      distance: 60,
-      strength: 0.95,
+      distance: 120, // 60→120: 가족도 약간 거리 유지
+      strength: 0.5, // 0.95→0.5
     },
     romantic: {
-      distance: 50,
-      strength: 0.95,
+      distance: 110, // 50→110: 로맨스도 적절한 거리
+      strength: 0.5, // 0.95→0.5
     },
     knows: {
-      distance: 220,
-      strength: 0.2,
+      distance: 180, // 220→180: 약간 가깝게
+      strength: 0.25, // 0.2→0.25
     },
     neutral: {
-      distance: 200,
+      distance: 170, // 200→170
       strength: 0.3,
     },
     rival: {
-      distance: 180, // Closer than enemy
-      strength: 0.4,
+      distance: 160, // 180→160: 라이벌은 가까이
+      strength: 0.35, // 0.4→0.35
     },
     enemy: {
-      distance: 300,
-      strength: 0.15, // Push away hard
+      distance: 200, // 300→200: 적도 너무 멀지 않게
+      strength: 0.25, // 0.15→0.25: 스프링 강화로 위치 안정
     },
     betrayed: {
-      distance: 250,
-      strength: 0.2,
+      distance: 190, // 250→190
+      strength: 0.25, // 0.2→0.25
     },
     complex: {
       distance: 150,
-      strength: 0.5,
+      strength: 0.35, // 0.5→0.35
     },
   },
 
@@ -444,24 +445,25 @@ export const RELATION_ANGLES: Record<string, number> = {
 
 export const SEMANTIC_FORCE_CONFIG = {
   // 관계별 가중치 (양수: 인력, 음수: 척력)
+  // 값을 완화하여 극단적 뭉침/흩어짐 방지
   relationWeights: {
-    ally: 1.5,
-    protects: 1.8,
-    mentor: 1.6,
-    family: 1.2,
-    romantic: 2.0,
-    knows: 0.3,
-    neutral: 0.5,
-    rival: -0.2, // Slight competition
-    enemy: -0.8, // Strong repulsion
-    betrayed: -0.5,
-    complex: 0.3,
+    ally: 0.6, // 1.5→0.6: 인력 대폭 완화
+    protects: 0.7, // 1.8→0.7
+    mentor: 0.6, // 1.6→0.6
+    family: 0.5, // 1.2→0.5
+    romantic: 0.8, // 2.0→0.8: 로맨스도 완화
+    knows: 0.2, // 0.3→0.2
+    neutral: 0.3, // 0.5→0.3
+    rival: -0.1, // -0.2→-0.1: 척력 완화
+    enemy: -0.3, // -0.8→-0.3: 적대 척력 대폭 완화
+    betrayed: -0.2, // -0.5→-0.2
+    complex: 0.2, // 0.3→0.2
   } as Record<string, number>,
-  defaultRepulsion: -1.0,
-  strengthMultiplier: 0.2,
-  attractionDistance: 40,
-  repulsionDistance: 100,
-  interGroupDistance: 1200, // 그룹 간 기본 거리
+  defaultRepulsion: -0.5, // -1.0→-0.5: 기본 척력 완화
+  strengthMultiplier: 0.1, // 0.2→0.1: 강도 배율 감소
+  attractionDistance: 25, // 40→25: 인력 거리 효과 감소
+  repulsionDistance: 50, // 100→50: 척력 거리 효과 대폭 감소
+  interGroupDistance: 800, // 1200→800: 그룹 간 거리 축소
 };
 
 // =====================================================

--- a/src/components/editor/InsightsPanel.tsx
+++ b/src/components/editor/InsightsPanel.tsx
@@ -459,15 +459,6 @@ export default function InsightsPanel({
 }: InsightsPanelProps) {
   const visibleConflicts = useMemo(() => {
     if (!consistencyReport) return [];
-    // DEBUG: 데이터 확인용 로그
-    console.log(
-      "[InsightsPanel] conflicts:",
-      consistencyReport.conflicts.map((c) => ({
-        id: c.id,
-        suggestedAction: c.suggestedAction,
-        description: c.description.slice(0, 30),
-      })),
-    );
     // FLAG_FOR_HUMAN만 필터링하여 사용자에게 표시
     return consistencyReport.conflicts.filter(
       (c) => c.suggestedAction === "FLAG_FOR_HUMAN",

--- a/src/hooks/useJobSSE.ts
+++ b/src/hooks/useJobSSE.ts
@@ -78,12 +78,22 @@ export function useJobSSE<T = unknown>(
   const onTimeoutRef = useRef(onTimeout);
   const onMessageRef = useRef(onMessage);
 
+  // State refs for onerror handler (stale closure 방지)
+  const resultRef = useRef<T | null>(null);
+  const jobStatusRef = useRef<JobStatus | null>(null);
+
   useEffect(() => {
     onCompleteRef.current = onComplete;
     onErrorRef.current = onError;
     onTimeoutRef.current = onTimeout;
     onMessageRef.current = onMessage;
   }, [onComplete, onError, onTimeout, onMessage]);
+
+  // Keep state refs in sync
+  useEffect(() => {
+    resultRef.current = result;
+    jobStatusRef.current = jobStatus;
+  }, [result, jobStatus]);
 
   // Cleanup function
   const cleanup = useCallback(() => {
@@ -242,7 +252,8 @@ export function useJobSSE<T = unknown>(
       // readyState 0 (CONNECTING) means it's trying to reconnect. Don't cleanup yet.
       // readyState 2 (CLOSED) means it gave up.
       if (eventSource.readyState === 2) {
-        if (!result && jobStatus !== "completed") {
+        // Use refs to get latest state (stale closure 방지)
+        if (!resultRef.current && jobStatusRef.current !== "completed") {
           setError("SSE 연결이 닫혔습니다.");
           setIsConnected(false);
           // Only cleanup if permanently closed

--- a/src/hooks/useProjectAnalysis.ts
+++ b/src/hooks/useProjectAnalysis.ts
@@ -13,7 +13,10 @@ import {
   startTransition,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useAnalysisBufferStore } from "@/stores/useAnalysisBufferStore";
+import {
+  useAnalysisBufferStore,
+  useAnalysisBufferHydrated,
+} from "@/stores/useAnalysisBufferStore";
 import { aiService } from "@/services/aiService";
 import { imageService } from "@/services/imageService";
 import type { AnalysisResultData, ConsistencyReport } from "@/types";
@@ -40,6 +43,8 @@ interface UseProjectAnalysisReturn {
   lastConsistencyReport: ConsistencyReport | null;
   isStuck: boolean;
   currentJobType: "analysis" | "image" | null;
+  /** 새로고침 후 백엔드에서 job 상태 확인 중 (true면 분석 버튼 비활성화) */
+  isCheckingJobStatus: boolean;
 }
 
 export function useProjectAnalysis(
@@ -49,9 +54,14 @@ export function useProjectAnalysis(
   const { enabled = true, onAnalysisComplete, onAnalysisError } = options;
   const queryClient = useQueryClient();
 
+  // IndexedDB에서 상태 복원 완료 여부 (새로고침 시 SSE 재연결에 필요)
+  const isHydrated = useAnalysisBufferHydrated();
+
   const [analysisProgress, setAnalysisProgress] = useState(0);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
   const [isStuck, setIsStuck] = useState(false);
+  // 새로고침 후 백엔드 job 상태 확인 중 (hydration 완료 전 또는 API 호출 중)
+  const [isCheckingJobStatus, setIsCheckingJobStatus] = useState(true);
 
   // Callbacks refs (to avoid effect re-runs)
   const onCompleteRef = useRef(onAnalysisComplete);
@@ -260,18 +270,20 @@ export function useProjectAnalysis(
     clearStoreJobs,
   ]);
 
-  // 프로젝트 ID 설정
+  // 프로젝트 ID 설정 (hydration 완료 후에만 - 복원된 상태 보존)
   useEffect(() => {
-    if (projectId) {
+    if (projectId && isHydrated) {
       setProjectId(projectId);
     }
-  }, [projectId, setProjectId]);
+  }, [projectId, isHydrated, setProjectId]);
 
   // 프로젝트 초기 로드 시 백엔드에서 job 상태 확인
+  // isHydrated: IndexedDB 복원 완료 후에만 실행 (새로고침 시 스토어 상태와 동기화)
   useEffect(() => {
-    if (!projectId || !enabled) return;
+    if (!projectId || !enabled || !isHydrated) return;
 
     const checkProjectJobStatus = async () => {
+      setIsCheckingJobStatus(true);
       try {
         const jobStatus = await aiService.getProjectAnalysisJob(projectId);
 
@@ -295,7 +307,9 @@ export function useProjectAnalysis(
         }
 
         // 이미 스토어에 분석 Job이 있으면 백엔드 Job을 추가하지 않음
+        // 단, isAnalyzing 상태는 true로 설정 (UI 표시용)
         if (currentStoreJobs.length > 0) {
+          setBufferAnalyzing(true);
           return;
         }
 
@@ -350,11 +364,20 @@ export function useProjectAnalysis(
           // 404 for analysis job status should only clear analysis jobs, not image jobs
           clearAnalysisJobs(projectId);
         }
+      } finally {
+        setIsCheckingJobStatus(false);
       }
     };
 
     checkProjectJobStatus();
-  }, [projectId, enabled, addStoreJobId, clearStoreJobs, clearAnalysisJobs]);
+  }, [
+    projectId,
+    enabled,
+    isHydrated,
+    addStoreJobId,
+    clearStoreJobs,
+    clearAnalysisJobs,
+  ]);
 
   // Note: SSE connection is managed by useJobSSE hook, so cleanup is handled there.
 
@@ -367,7 +390,11 @@ export function useProjectAnalysis(
     projectId,
     aiService.getProjectStatusStreamUrl,
     {
-      enabled: !!projectId && (activeAnalysisJobs[projectId]?.length ?? 0) > 0,
+      // isHydrated: IndexedDB에서 상태 복원 완료 후에만 SSE 시작 (새로고침 시 연결 끊김 방지)
+      enabled:
+        !!projectId &&
+        isHydrated &&
+        (activeAnalysisJobs[projectId]?.length ?? 0) > 0,
       onMessage: async (data) => {
         // SSE 이벤트 파싱
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -950,5 +977,6 @@ export function useProjectAnalysis(
     lastConsistencyReport,
     isStuck,
     currentJobType,
+    isCheckingJobStatus,
   };
 }

--- a/src/hooks/useProjectAnalysis.ts
+++ b/src/hooks/useProjectAnalysis.ts
@@ -29,7 +29,10 @@ import { characterKeys } from "./useCharacters";
 
 interface UseProjectAnalysisOptions {
   enabled?: boolean;
-  onAnalysisComplete?: (result: AnalysisResultData | null) => void;
+  onAnalysisComplete?: (
+    result: AnalysisResultData | null,
+    jobId: string,
+  ) => void;
   onAnalysisError?: (error: string) => void;
 }
 
@@ -149,126 +152,133 @@ export function useProjectAnalysis(
   }, [currentJobType]);
 
   // Finalize Analysis (Shared logic for all completion paths)
-  const finalizeAnalysis = useCallback(async () => {
-    // Check if component is still mounted
-    if (!isMountedRef.current) {
-      return;
-    }
-    if (isRequestingRef.current) {
-      return;
-    }
-    if (isFinalizingRef.current) {
-      return;
-    }
-
-    isFinalizingRef.current = true;
-
-    // Get current state to check job type (fallback to refs if store was just cleared)
-    const { pendingDocuments } = useAnalysisBufferStore.getState();
-    const activeType =
-      useAnalysisBufferStore.getState().currentJobType ||
-      lastKnownJobTypeRef.current;
-    const activeTargetId =
-      useAnalysisBufferStore.getState().currentJobTargetId ||
-      lastKnownTargetIdRef.current;
-
-    // 1. Analysis-specific state sync
-    if (activeType === "analysis") {
-      // Sync hashes (분석 완료된 문서들)
-      setLastAnalyzedHashes(pendingDocuments);
-
-      // pendingDocuments 클리어
-      useAnalysisBufferStore.getState().clearPendingDocuments();
-    }
-
-    // 2. Cache Invalidation FIRST, then callback (새 데이터 로드 후 diff 계산)
-    if (projectId) {
-      // Always invalidate character list as both jobs might affect it
-      await queryClient.invalidateQueries({
-        queryKey: characterKeys.list(projectId),
-      });
-
-      // Invalidate project events as analysis might update the timeline
-      await queryClient.invalidateQueries({
-        queryKey: ["events", "project", projectId],
-      });
-
-      // Invalidate project stats
-      queryClient.invalidateQueries({
-        queryKey: ["projects", "detail", projectId, "stats"],
-      });
-
-      if (activeType === "image" && activeTargetId) {
-        // Also invalidate detail query for the specific character
-        queryClient.invalidateQueries({
-          queryKey: characterKeys.detail(activeTargetId),
-        });
+  const finalizeAnalysis = useCallback(
+    async (manualJobId?: string) => {
+      // Check if component is still mounted
+      if (!isMountedRef.current) {
+        return;
       }
-    }
+      if (isRequestingRef.current) {
+        return;
+      }
+      if (isFinalizingRef.current) {
+        return;
+      }
 
-    // 3. Trigger completion callback AFTER invalidation (새 데이터 로드 완료 후)
-    if (activeType === "analysis") {
-      onCompleteRef.current?.(lastResultRef.current);
-    }
+      isFinalizingRef.current = true;
 
-    // Logic to ensure consistency report availability
-    if (activeType === "analysis") {
-      let report: ConsistencyReport | null =
-        lastResultRef.current?.consistencyReport || null;
+      // Get current state to check job type (fallback to refs if store was just cleared)
+      const storeState = useAnalysisBufferStore.getState();
+      const { pendingDocuments } = storeState;
+      const activeType =
+        storeState.currentJobType || lastKnownJobTypeRef.current;
+      const activeTargetId =
+        storeState.currentJobTargetId || lastKnownTargetIdRef.current;
 
-      if (!report && projectId) {
-        try {
-          // Try fetching from API first
-          const backendReport = await aiService.getConsistencyReport(projectId);
-          report = transformConsistencyReport(backendReport);
-        } catch (error) {
-          console.warn(
-            "[useProjectAnalysis] Real API failed, trying mock:",
-            error,
-          );
-          // Fallback to mock (simulating backend)
-          try {
-            const mockBackendReport =
-              await aiService.mockGetConsistencyReport(projectId);
-            report = transformConsistencyReport(mockBackendReport);
-          } catch (mockErr) {
-            console.error(
-              "[useProjectAnalysis] Mock fetch also failed:",
-              mockErr,
-            );
-          }
+      // IMPORTANT: Get the jobId that is completing
+      const activeJobId =
+        manualJobId ||
+        storeState.currentJobId ||
+        (projectId ? storeState.activeAnalysisJobs[projectId]?.[0] : null);
+
+      // 1. Analysis-specific state sync
+      if (activeType === "analysis") {
+        // Sync hashes (분석 완료된 문서들)
+        setLastAnalyzedHashes(pendingDocuments);
+
+        // pendingDocuments 클리어
+        useAnalysisBufferStore.getState().clearPendingDocuments();
+      }
+
+      // 2. Cache Invalidation FIRST, then callback (새 데이터 로드 후 diff 계산)
+      if (projectId) {
+        // Always invalidate character list as both jobs might affect it
+        await queryClient.invalidateQueries({
+          queryKey: characterKeys.list(projectId),
+        });
+
+        // Invalidate project events as analysis might update the timeline
+        await queryClient.invalidateQueries({
+          queryKey: ["events", "project", projectId],
+        });
+
+        // Invalidate project stats
+        queryClient.invalidateQueries({
+          queryKey: ["projects", "detail", projectId, "stats"],
+        });
+
+        if (activeType === "image" && activeTargetId) {
+          // Also invalidate detail query for the specific character
+          queryClient.invalidateQueries({
+            queryKey: characterKeys.detail(activeTargetId),
+          });
         }
       }
 
-      if (report) {
-        useAnalysisBufferStore.getState().setLastConsistencyReport(report);
+      // 3. Trigger completion callback AFTER invalidation (새 데이터 로드 완료 후)
+      if (activeType === "analysis") {
+        console.log("[Animation Debug] Finalizing Analysis Callback", {
+          activeJobId,
+          result: !!lastResultRef.current,
+          hasCallback: !!onCompleteRef.current,
+        });
+        onCompleteRef.current?.(lastResultRef.current, activeJobId || "");
       }
-    }
 
-    lastResultRef.current = null;
-    lastKnownJobTypeRef.current = null;
-    lastKnownTargetIdRef.current = null;
+      // Logic to ensure consistency report availability
+      if (activeType === "analysis") {
+        let report: ConsistencyReport | null =
+          lastResultRef.current?.consistencyReport || null;
 
-    // Clear jobs
-    if (projectId) {
-      clearStoreJobs(projectId);
-    }
+        if (!report && projectId) {
+          try {
+            // Try fetching from API first
+            const backendReport =
+              await aiService.getConsistencyReport(projectId);
+            report = transformConsistencyReport(backendReport);
+          } catch (_error) {
+            // Fallback to mock (simulating backend)
+            try {
+              const mockBackendReport =
+                await aiService.mockGetConsistencyReport(projectId);
+              report = transformConsistencyReport(mockBackendReport);
+            } catch (_mockErr) {
+              // ignore
+            }
+          }
+        }
 
-    // 모든 분석 완료 처리 (자동 재분석은 사용자 요청 시에만 수행하도록 루프 제거)
-    setBufferAnalyzing(false);
-    setAnalysisProgress(100);
-    setGlobalProgress(100);
+        if (report) {
+          useAnalysisBufferStore.getState().setLastConsistencyReport(report);
+        }
+      }
 
-    // 완료 처리 끝났으므로 플래그 리셋 (다음 분석을 위해)
-    isFinalizingRef.current = false;
-  }, [
-    projectId,
-    queryClient,
-    setBufferAnalyzing,
-    setGlobalProgress,
-    setLastAnalyzedHashes,
-    clearStoreJobs,
-  ]);
+      lastResultRef.current = null;
+      lastKnownJobTypeRef.current = null;
+      lastKnownTargetIdRef.current = null;
+
+      // Clear jobs
+      if (projectId) {
+        clearStoreJobs(projectId);
+      }
+
+      // 모든 분석 완료 처리 (자동 재분석은 사용자 요청 시에만 수행하도록 루프 제거)
+      setBufferAnalyzing(false);
+      setAnalysisProgress(100);
+      setGlobalProgress(100);
+
+      // 완료 처리 끝났으므로 플래그 리셋 (다음 분석을 위해)
+      isFinalizingRef.current = false;
+    },
+    [
+      projectId,
+      queryClient,
+      setBufferAnalyzing,
+      setGlobalProgress,
+      setLastAnalyzedHashes,
+      clearStoreJobs,
+    ],
+  );
 
   // 프로젝트 ID 설정 (hydration 완료 후에만 - 복원된 상태 보존)
   useEffect(() => {
@@ -292,25 +302,10 @@ export function useProjectAnalysis(
         const currentStoreJobs =
           useAnalysisBufferStore.getState().activeAnalysisJobs[projectId] || [];
 
-        // Debug: 현재 스토어 상태와 백엔드 응답 비교
-        if (process.env.NODE_ENV === "development") {
-          console.log("[Job Status Debug]", {
-            backendJobId: jobStatus.jobId,
-            backendStatus: jobStatus.status,
-            currentStoreJobs,
-            willAddJob:
-              jobStatus.jobId &&
-              (jobStatus.status === "processing" ||
-                jobStatus.status === "pending") &&
-              currentStoreJobs.length === 0, // 스토어가 비어있을 때만 추가
-          });
-        }
-
-        // 이미 스토어에 분석 Job이 있으면 백엔드 Job을 추가하지 않음
-        // 단, isAnalyzing 상태는 true로 설정 (UI 표시용)
+        // 2024-01-16 Fix: Don't return early if store has jobs.
+        // We must proceed to verify backend status to trigger completion if needed.
         if (currentStoreJobs.length > 0) {
           setBufferAnalyzing(true);
-          return;
         }
 
         // 진행 중인 job이 있으면 SSE 연결을 위해 스토어에 추가
@@ -340,21 +335,47 @@ export function useProjectAnalysis(
             // 오래된(Stuck) 작업은 유령 작업으로 간주하여 제거
             clearStoreJobs(projectId);
           } else {
-            addStoreJobId(projectId, jobStatus.jobId, "analysis");
+            // 스토어에 없는 경우에만 추가 (중복 방지)
+            if (!currentStoreJobs.includes(jobStatus.jobId!)) {
+              addStoreJobId(projectId, jobStatus.jobId!, "analysis");
+            }
+
             setJobProgresses((prev) => ({
               ...prev,
               [jobStatus.jobId!]: jobStatus.progress || 0,
             }));
+
+            // 전역 프로그레스도 동기화
+            setAnalysisProgress(jobStatus.progress || 0);
+            setGlobalProgress(jobStatus.progress || 0);
           }
         }
-        // 완료된 상태면 캐릭터/관계 쿼리 무효화 (DB에서 최신 데이터 fetch)
+        // 완료된 상태면 캐릭터/관계 쿼리 무효화 및 완료 처리
         else if (
           jobStatus.status === "failed" ||
           jobStatus.status === "completed"
         ) {
           // 서버가 명시적으로 "완료됨" 혹은 "실패함"이라고 응답하면,
-          // 클라이언트가 알고 있는 모든 진행 중 작업을 정리합니다. (Ghost Job 방지)
-          clearStoreJobs(projectId);
+          // finalizeAnalysis를 호출하여 onAnalysisComplete 콜백을 트리거합니다.
+          // (WorldPage에서 Acknowledgement 체크 후 모달 표시)
+
+          // 1. 결과가 있으면 ref에 저장 (finalizeAnalysis에서 사용)
+          // Note: getProjectAnalysisJob 응답에는 result가 없을 수도 있음 (가벼운 상태 조회)
+          // finalizeAnalysis 내부에서 fetch 로직이 돌겠지만, 여기서는 trigger만 해줌.
+
+          // 2024-01-16 Fix: 단순히 clearStoreJobs만 하면 콜백이 안 불려서 모달이 안 뜸.
+          // finalizeAnalysis를 통해 정상적인 완료 플로우를 타게 함.
+          if (!isFinalizingRef.current) {
+            // 강제로 100%로 맞춤
+            setAnalysisProgress(100);
+
+            // 만약 현재 스토어에 Job ID가 없다면(새로고침 직후), 잠시 추가해둬야 finalize 로직이 돔
+            if (jobStatus.jobId && currentStoreJobs.length === 0) {
+              addStoreJobId(projectId, jobStatus.jobId, "analysis");
+            }
+
+            await finalizeAnalysis(jobStatus.jobId!);
+          }
         }
       } catch (error) {
         // API가 404라면 해당 프로젝트에 진행 중인 Job이 없다는 뜻이므로 로컬 상태도 클리어
@@ -377,6 +398,9 @@ export function useProjectAnalysis(
     addStoreJobId,
     clearStoreJobs,
     clearAnalysisJobs,
+    finalizeAnalysis,
+    setBufferAnalyzing,
+    setGlobalProgress,
   ]);
 
   // Note: SSE connection is managed by useJobSSE hook, so cleanup is handled there.
@@ -441,16 +465,6 @@ export function useProjectAnalysis(
         }
 
         // Debug log for SSE progress tracking
-        if (process.env.NODE_ENV === "development") {
-          console.log("[SSE Progress Debug]", {
-            eventJobId,
-            eventType,
-            rawProgress: { percent: event.percent, progress: event.progress },
-            totalDocs: event.totalDocuments,
-            completedDocs: event.completedDocuments,
-            calculatedProgress: currentProgress,
-          });
-        }
 
         if (eventType === "progress" || eventType === "processing") {
           setJobProgresses((prev) => ({
@@ -759,15 +773,7 @@ export function useProjectAnalysis(
         if (jobId) {
           // Debug: 문서별 분석 Job ID 추가
           if (process.env.NODE_ENV === "development") {
-            const currentStoreJobs =
-              useAnalysisBufferStore.getState().activeAnalysisJobs[projectId] ||
-              [];
-            console.log("[triggerAnalysis Debug]", {
-              documentId: chunk.documentId,
-              newJobId: jobId,
-              currentStoreJobs,
-              isNewJob: !currentStoreJobs.includes(jobId),
-            });
+            // Log if needed
           }
           addStoreJobId(projectId, jobId);
           setJobProgresses((prev) => ({ ...prev, [jobId]: 0 }));

--- a/src/hooks/useProjectAnalysis.ts
+++ b/src/hooks/useProjectAnalysis.ts
@@ -217,11 +217,6 @@ export function useProjectAnalysis(
 
       // 3. Trigger completion callback AFTER invalidation (새 데이터 로드 완료 후)
       if (activeType === "analysis") {
-        console.log("[Animation Debug] Finalizing Analysis Callback", {
-          activeJobId,
-          result: !!lastResultRef.current,
-          hasCallback: !!onCompleteRef.current,
-        });
         onCompleteRef.current?.(lastResultRef.current, activeJobId || "");
       }
 

--- a/src/pages/editor/EditorPage.tsx
+++ b/src/pages/editor/EditorPage.tsx
@@ -293,11 +293,12 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
   // const [analysisDiff, setAnalysisDiff] = useState<AnalysisDiff | null>(null);
 
   // consistencyReport state removed in favor of store persistence
-  const addToBuffer = useAnalysisBufferStore(
-    (state) =>
-      (state as { addToBuffer: (projectId: string, content: string) => void })
-        .addToBuffer,
-  );
+  const {
+    addToBuffer,
+    setPendingViewJobId,
+    setAnalysisSnapshot,
+    isJobAcknowledged,
+  } = useAnalysisBufferStore();
 
   const readerChapters = useMemo(() => {
     interface FlatChapter {
@@ -332,19 +333,22 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
     lastConsistencyReport, // Added
   } = useProjectAnalysis(projectId, {
     enabled: !!projectId,
-    onAnalysisComplete: async (result: AnalysisResultData | null) => {
-      if (!result) return;
+    onAnalysisComplete: async (
+      _result: AnalysisResultData | null,
+      jobId: string,
+    ) => {
+      // Note: result might be null if job was found completed on mount
+      // We still want to set the pending view flag so WorldPage can show the result.
 
-      // Check if already acknowledged (Viewed) to prevent loop
-      const isAck =
-        sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true";
+      // Check if this specific jobId is already acknowledged
+      const isAck = isJobAcknowledged(jobId);
       if (isAck) return;
 
       // Analysis complete.
       // We DO NOT calculate diff here anymore. We defer it to WorldPage.
-      // Flag that we have a pending view for the user.
+      // Flag that we have a pending view for the user using persistent store.
       if (projectId) {
-        sessionStorage.setItem(`analysis_pending_view_${projectId}`, "true");
+        setPendingViewJobId(jobId);
       }
 
       toast({
@@ -449,23 +453,22 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
     };
     snapshotRef.current = snapshot;
 
-    // Persist to sessionStorage to share with WorldPage
+    // Persist to store to share with WorldPage (IDB persistence)
     if (projectId) {
-      try {
-        sessionStorage.setItem(
-          `analysis_snapshot_${projectId}`,
-          JSON.stringify(snapshot),
-        );
-        // Reset flags
-        sessionStorage.setItem(`analysis_acknowledged_${projectId}`, "false");
-        sessionStorage.removeItem(`analysis_pending_view_${projectId}`);
-      } catch (e) {
-        console.warn("Failed to save snapshot to sessionStorage", e);
-      }
+      setAnalysisSnapshot(projectId, snapshot);
+      // Reset pending view for new session
+      setPendingViewJobId(null);
     }
 
     handleManualAnalysis();
-  }, [handleManualAnalysis, characters, graphLinks, projectId]);
+  }, [
+    handleManualAnalysis,
+    characters,
+    graphLinks,
+    projectId,
+    setAnalysisSnapshot,
+    setPendingViewJobId,
+  ]);
 
   // ============================================================
   // UI & Modals State

--- a/src/pages/editor/EditorPage.tsx
+++ b/src/pages/editor/EditorPage.tsx
@@ -76,7 +76,7 @@ interface DemoChapterTreeNode extends DocumentTreeNode {
 }
 
 function buildDemoChapterTree(
-  chapters: typeof DEMO_CHAPTERS
+  chapters: typeof DEMO_CHAPTERS,
 ): DemoChapterTreeNode[] {
   const map = new Map<string, DemoChapterTreeNode>();
   const roots: DemoChapterTreeNode[] = [];
@@ -120,7 +120,7 @@ function buildDemoChapterTree(
  * Helper to map DocumentTreeNode to ChapterNode for the sidebar
  */
 function mapToChapterNodes(
-  nodes: DocumentTreeNode[]
+  nodes: DocumentTreeNode[],
 ): import("@/components/editor/sidebar/types").ChapterNode[] {
   return nodes.map((node) => ({
     id: node.id,
@@ -154,7 +154,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
 
   const debouncedSetCharacterCount = useMemo(
     () => debounce((count: number) => setCharacterCount(count), 1000),
-    []
+    [],
   );
 
   useEffect(() => {
@@ -164,10 +164,10 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
   }, [debouncedSetCharacterCount]);
 
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(
-    isDemo ? "chapter-demo-1" : null
+    isDemo ? "chapter-demo-1" : null,
   );
   const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
-    isDemo ? "chapter-1-1" : null
+    isDemo ? "chapter-1-1" : null,
   );
   const [viewMode, setViewMode] = useState<
     "editor" | "scrivenings" | "outline"
@@ -188,14 +188,14 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
   */
 
   const typewriterMode = useEditorSettingStore(
-    (state) => state.behavior.typewriterMode
+    (state) => state.behavior.typewriterMode,
   );
   const setTypewriterMode = useEditorSettingStore(
-    (state) => state.setTypewriterMode
+    (state) => state.setTypewriterMode,
   );
   const isTypewriterMode = typewriterMode !== "off";
   const isFocusMode = useEditorSettingStore(
-    (state) => state.behavior.focusMode
+    (state) => state.behavior.focusMode,
   );
   const setFocusMode = useEditorSettingStore((state) => state.setFocusMode);
   /* performanceMode removed */
@@ -219,16 +219,16 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
   useDocumentTree(isDemo ? "" : projectId);
 
   const allDocuments = useDocumentStore(
-    (state) => (state as { documents: Record<string, Document> }).documents
+    (state) => (state as { documents: Record<string, Document> }).documents,
   );
   const localDocuments = useMemo(
     () =>
       isDemo
         ? []
         : Object.values(allDocuments).filter(
-            (doc) => doc.projectId === projectId
+            (doc) => doc.projectId === projectId,
           ),
-    [allDocuments, projectId, isDemo]
+    [allDocuments, projectId, isDemo],
   );
 
   const previewChapters = useMemo(() => {
@@ -244,7 +244,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
 
   const documents = useMemo(
     () => Object.values(localDocuments),
-    [localDocuments]
+    [localDocuments],
   );
 
   // 통계 스토어 연결
@@ -252,10 +252,10 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
 
   // 통계 스토어 연결
   const updateDocumentCharCount = useWritingStatsStore(
-    (s) => s.updateDocumentCharCount
+    (s) => s.updateDocumentCharCount,
   );
   const setDocumentCharCounts = useWritingStatsStore(
-    (s) => s.setDocumentCharCounts
+    (s) => s.setDocumentCharCounts,
   );
 
   // 스로틀링된 통계 업데이트 함수 (1초에 한 번만 실행하여 렉 방지)
@@ -265,14 +265,14 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
         (
           id: string,
           count: number,
-          updateFn: (id: string, count: number) => void
+          updateFn: (id: string, count: number) => void,
         ) => {
           updateFn(id, count);
         },
         1000,
-        { leading: true, trailing: true }
+        { leading: true, trailing: true },
       ),
-    []
+    [],
   );
 
   // 스로틀링된 UI 업데이트 함수 (300ms에 한 번만 실행하여 리렌더링 방지)
@@ -283,16 +283,16 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
           count: number,
           callback: (
             count: number,
-            setState: React.Dispatch<React.SetStateAction<number>>
+            setState: React.Dispatch<React.SetStateAction<number>>,
           ) => void,
-          setter: React.Dispatch<React.SetStateAction<number>>
+          setter: React.Dispatch<React.SetStateAction<number>>,
         ) => {
           callback(count, setter);
         },
         500,
-        { leading: true, trailing: true }
+        { leading: true, trailing: true },
       ),
-    []
+    [],
   );
 
   // 초기 로드 시 모든 문서의 글자수를 스토어에 설정
@@ -304,7 +304,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
       });
       setDocumentCharCounts(counts);
     }
-  }, [documents.length, isDemo, setDocumentCharCounts]); // documents.length로 첫 로드 시에만 실행
+  }, [documents, isDemo, setDocumentCharCounts]);
 
   const sidebarChapters = useMemo(() => {
     if (isDemo)
@@ -447,7 +447,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
         // Failed to save content
       }
     },
-    [isDemo, selectedSectionId, saveDocumentContent, addToBuffer]
+    [isDemo, selectedSectionId, saveDocumentContent, addToBuffer],
   );
 
   const saveWithAnalysis = useCallback(
@@ -456,7 +456,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
       await saveContent(content);
       addToBuffer(selectedSectionId, content);
     },
-    [saveContent, selectedSectionId, addToBuffer]
+    [saveContent, selectedSectionId, addToBuffer],
   );
 
   const handleManualAnalysis = useCallback(() => {
@@ -601,7 +601,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
     (docId: string) => {
       handleSelectSection(docId);
     },
-    [handleSelectSection]
+    [handleSelectSection],
   );
 
   // Modal Handlers
@@ -614,12 +614,12 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
 
   const handleConfirmCreateSection = async (
     title: string,
-    type: "chapter" | "section"
+    type: "chapter" | "section",
   ) => {
     await handleAddChapter(
       title,
       selectedFolderId || undefined,
-      type === "chapter" ? "chapter" : "section"
+      type === "chapter" ? "chapter" : "section",
     );
     setCreateSectionModalOpen(false);
   };
@@ -681,14 +681,14 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
 
   const isRightSidebarOpen = useUIStore((state) => state.rightSidebarOpen);
   const setIsRightSidebarOpen = useUIStore(
-    (state) => state.setRightSidebarOpen
+    (state) => state.setRightSidebarOpen,
   );
 
   return (
     <div
       className={cn(
         "flex flex-col bg-cloud-50/50 text-foreground", // Unified Desk Background
-        isDemo ? "h-screen" : "h-full"
+        isDemo ? "h-screen" : "h-full",
       )}
     >
       {isDemo && (
@@ -724,7 +724,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
           className={cn(
             "flex-1 flex flex-col transition-all duration-300 relative z-10",
             isTypewriterMode ? "items-center" : "",
-            isFocusMode && "bg-cloud-50"
+            isFocusMode && "bg-cloud-50",
             // Main area is transparent to show Desk, unless Focus Mode
           )}
         >
@@ -780,7 +780,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
                 throttledUIUpdate(
                   count,
                   handleCharacterCountChange,
-                  setCharacterCount
+                  setCharacterCount,
                 );
 
                 // 현재 문서의 글자수를 스토어에 저장 (실시간 동기화 - 1000ms 스로틀링)
@@ -788,7 +788,7 @@ export default function EditorPage({ isDemo: isDemoProp }: EditorPageProps) {
                   throttledUpdateStats(
                     selectedSectionId,
                     count,
-                    updateDocumentCharCount
+                    updateDocumentCharCount,
                   );
                 }
               }}

--- a/src/pages/editor/hooks/useEditorHandlers.ts
+++ b/src/pages/editor/hooks/useEditorHandlers.ts
@@ -118,9 +118,8 @@ export function useEditorHandlers({
     if (documentId && content && saveContentRef.current) {
       try {
         await saveContentRef.current(content);
-        console.log(`[forceSave] Saved content for document: ${documentId}`);
-      } catch (error) {
-        console.error("[EditorPage] Force save failed:", error);
+      } catch (_error) {
+        // ignore
       }
     }
   }, [isDemo]);
@@ -233,9 +232,6 @@ export function useEditorHandlers({
         const nowDocId = selectedSectionIdRef.current;
 
         if (savedDocId !== nowDocId) {
-          console.log(
-            `[Auto-save] Cancelled: Document changed from ${savedDocId} to ${nowDocId}`,
-          );
           return; // Don't save to wrong document!
         }
 
@@ -243,8 +239,7 @@ export function useEditorHandlers({
         try {
           await saveContentRef.current(content);
           setSaveStatusRef.current("saved");
-        } catch (error) {
-          console.error("[EditorPage] Auto-save failed:", error);
+        } catch (_error) {
           setSaveStatusRef.current("unsaved");
         }
       }, 500);
@@ -308,11 +303,7 @@ export function useEditorHandlers({
           saveTimeoutRef.current = null;
         }
         await forceSave();
-      } catch (error) {
-        console.error(
-          "[handleAddSection] Failed to save before creating section:",
-          error,
-        );
+      } catch (_error) {
         // 저장 실패해도 섹션 생성은 계속 진행 (사용자 경험 우선)
       }
 
@@ -367,8 +358,7 @@ export function useEditorHandlers({
       // 2. Sync with Backend
       try {
         await updateDocumentMutation(id, { title: newTitle });
-      } catch (error) {
-        console.error("Failed to rename chapter:", error);
+      } catch (_error) {
         // 3. Rollback on failure: Revert to previous title if API fails
         if (previousTitle !== undefined) {
           _update(id, { title: previousTitle });

--- a/src/pages/editor/hooks/useKeyboardSave.ts
+++ b/src/pages/editor/hooks/useKeyboardSave.ts
@@ -4,7 +4,10 @@ interface UseKeyboardSaveOptions {
   isDemo: boolean;
   selectedSectionId: string | null;
   saveContentRef: React.RefObject<(content: string) => Promise<void>>;
-  lastContentRef: React.RefObject<string>;
+  lastContentRef: React.RefObject<{
+    documentId: string | null;
+    content: string;
+  }>;
   saveTimeoutRef: React.RefObject<ReturnType<typeof setTimeout> | null>;
   getLatestContent?: () => string;
 }
@@ -34,7 +37,7 @@ export function useKeyboardSave({
             // Get content from callback if available (for debounced editors), otherwise use ref
             const contentToSave = getLatestContent
               ? getLatestContent()
-              : lastContentRef.current || "";
+              : lastContentRef.current?.content || "";
 
             // If content is empty strings, we should still save if that's the intention,
             // but usually we want to fallback to lastContentRef if getContent returns empty?

--- a/src/pages/stats/StatsPage.tsx
+++ b/src/pages/stats/StatsPage.tsx
@@ -20,7 +20,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/design-system/components/Button";
 import { Label } from "@/components/ui/label";
 import { ChapterBalanceCard } from "@/components/stats/ChapterBalanceCard";
 import { WritingPatternsCard } from "@/components/stats/WritingPatternsCard";
@@ -80,7 +80,7 @@ export default function StatsPage() {
     projectId || "",
     {
       enabled: !!projectId,
-    }
+    },
   );
 
   // Real data from IndexedDB
@@ -105,19 +105,19 @@ export default function StatsPage() {
       // 스토어 값 사용 (에디터에서 실시간 업데이트됨)
       wordCount = Object.values(documentCharCounts).reduce(
         (acc, count) => acc + count,
-        0
+        0,
       );
     } else {
       // 폴백: 문서에서 직접 계산
       wordCount = documents.reduce(
         (acc, doc) => acc + getPlainTextLength(doc.content),
-        0
+        0,
       );
     }
 
     // 폴더 또는 챕터 타입인 문서의 수 계산
     const chapterCount = documents.filter(
-      (doc) => doc.type === "folder" || doc.type === "text"
+      (doc) => doc.type === "folder" || doc.type === "text",
     ).length;
 
     return {
@@ -319,7 +319,7 @@ export default function StatsPage() {
                         "w-4 h-4",
                         displayStreak > 0
                           ? "text-[#B38B82] fill-[#B38B82]"
-                          : "text-cloud-200"
+                          : "text-cloud-200",
                       )}
                     />
                   </motion.div>
@@ -433,7 +433,7 @@ export default function StatsPage() {
                           <motion.div
                             className={cn(
                               "w-full h-full rounded-[2px] cursor-pointer",
-                              getIntensityColor(day.count)
+                              getIntensityColor(day.count),
                             )}
                             variants={{
                               initial: { opacity: 0, scale: 0.5 },
@@ -539,16 +539,10 @@ export default function StatsPage() {
             </div>
           </div>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsGoalDialogOpen(false)}
-            >
+            <Button intent="outline" onClick={() => setIsGoalDialogOpen(false)}>
               취소
             </Button>
-            <Button
-              onClick={handleSaveGoal}
-              className="bg-mocha-500 hover:bg-mocha-600"
-            >
+            <Button onClick={handleSaveGoal} intent="primary">
               저장하기
             </Button>
           </DialogFooter>

--- a/src/pages/world/WorldPage.tsx
+++ b/src/pages/world/WorldPage.tsx
@@ -124,8 +124,6 @@ export default function WorldPage() {
     isCheckingJobStatus,
   } = useProjectAnalysis(projectId ?? null, {
     onAnalysisComplete: (_result, jobId) => {
-      console.log("[Animation Debug] onAnalysisComplete", { jobId });
-      // Persistent flag will trigger the useEffect below
       setPendingViewJobId(jobId);
     },
   });
@@ -133,23 +131,13 @@ export default function WorldPage() {
   // Check for Pending Analysis View (from Editor)
   useEffect(() => {
     if (projectId) {
-      console.log("[Animation Debug] Pending View Check", { pendingViewJobId });
-
       if (pendingViewJobId && pendingViewJobId !== "") {
         const isAck = isJobAcknowledged(pendingViewJobId);
 
         if (isAck) {
-          console.log(
-            "[Animation Debug] Pending View - Already Ack, skipping",
-            { pendingViewJobId },
-          );
           setPendingViewJobId(null);
           return;
         }
-
-        console.log("[Animation Debug] Pending View - Triggering Animation", {
-          pendingViewJobId,
-        });
 
         // Decouple from render cycle to avoid cascading renders warning
         setTimeout(() => {
@@ -160,9 +148,6 @@ export default function WorldPage() {
 
         // Trigger the completion flow immediately
         setTimeout(() => {
-          console.log(
-            "[Animation Debug] Pending View - Setting isWaitingForRefresh(true)",
-          );
           setIsWaitingForRefresh(true);
         }, 50);
       }
@@ -253,23 +238,9 @@ export default function WorldPage() {
       ? isJobAcknowledged(currentAnalysisJobId)
       : false;
 
-    console.log("[Animation Debug] Diff Effect Check", {
-      isWaitingForRefresh,
-      isPolling,
-      isCheckingJobStatus,
-      currentAnalysisJobId,
-      showCompletionAnimation,
-      isAck,
-      isAnalysisModalOpen,
-      animatingRef: animatingJobIdRef.current,
-    });
-
     if (!isWaitingForRefresh || isPolling || isCheckingJobStatus) return;
 
     if (isAck || isAnalysisModalOpen) {
-      console.log(
-        "[Animation Debug] Diff Effect - Skipping (isAck or isModalOpen)",
-      );
       setTimeout(() => setIsWaitingForRefresh(false), 0);
       return;
     }
@@ -281,10 +252,6 @@ export default function WorldPage() {
       currentAnalysisJobId &&
       animatingJobIdRef.current === currentAnalysisJobId
     ) {
-      console.log(
-        "[Animation Debug] Diff Effect - Already animating this job, ignoring update",
-        currentAnalysisJobId,
-      );
       return;
     }
     animatingJobIdRef.current = currentAnalysisJobId;
@@ -319,15 +286,6 @@ export default function WorldPage() {
     const minDisplayTime = 2000;
 
     const timer = setTimeout(() => {
-      console.log("[Animation Debug] Timer Finished - Opening Modal", {
-        jobId: currentAnalysisJobId,
-        isDiffEmpty:
-          !diff ||
-          (diff.newCharacters.length === 0 &&
-            diff.updatedCharacters.length === 0 &&
-            diff.newRelations.length === 0),
-      });
-
       // Synchronous updates to ensure UI consistency
       setIsWaitingForRefresh(false);
       setAnalysisDiff(diff);

--- a/src/pages/world/WorldPage.tsx
+++ b/src/pages/world/WorldPage.tsx
@@ -80,8 +80,17 @@ export default function WorldPage() {
 
   const updateCharacterMutation = useUpdateCharacter();
 
-  const setJobId = useAnalysisBufferStore((state) => state.setJobId);
-  const setAnalyzing = useAnalysisBufferStore((state) => state.setAnalyzing);
+  const {
+    setJobId,
+    setAnalyzing,
+    pendingViewJobId,
+    setPendingViewJobId,
+    analysisSnapshots,
+    setAnalysisSnapshot,
+    clearAnalysisSnapshot,
+    acknowledgeJob,
+    isJobAcknowledged,
+  } = useAnalysisBufferStore();
 
   const [analysisDiff, setAnalysisDiff] = useState<AnalysisDiff | null>(null);
   const [isAnalysisModalOpen, setIsAnalysisModalOpen] = useState(false);
@@ -99,6 +108,10 @@ export default function WorldPage() {
   const [analysisChanges, setAnalysisChanges] = useState<
     Record<string, "new" | "updated" | null>
   >({});
+  const [currentAnalysisJobId, setCurrentAnalysisJobId] = useState<
+    string | null
+  >(null);
+  const animatingJobIdRef = useRef<string | null>(null);
 
   // Polling for analysis status (Global)
   const {
@@ -108,61 +121,65 @@ export default function WorldPage() {
     isStuck,
     currentJobType,
     flushAndAnalyze,
+    isCheckingJobStatus,
   } = useProjectAnalysis(projectId ?? null, {
-    onAnalysisComplete: (_result) => {
-      // guard: Check acknowledgement
-      if (
-        projectId &&
-        sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true"
-      ) {
-        return;
-      }
-      // 분석 완료 애니메이션 표시 (결과 유무와 관계없이)
-      setShowCompletionAnimation(true);
-
-      // Trigger waiting state for data refresh
-      // Diff calculation will happen in useEffect once data is updated
-      setIsWaitingForRefresh(true);
+    onAnalysisComplete: (_result, jobId) => {
+      console.log("[Animation Debug] onAnalysisComplete", { jobId });
+      // Persistent flag will trigger the useEffect below
+      setPendingViewJobId(jobId);
     },
   });
 
   // Check for Pending Analysis View (from Editor)
   useEffect(() => {
     if (projectId) {
-      const pendingView = sessionStorage.getItem(
-        `analysis_pending_view_${projectId}`,
-      );
-      if (pendingView === "true") {
-        sessionStorage.removeItem(`analysis_pending_view_${projectId}`);
+      console.log("[Animation Debug] Pending View Check", { pendingViewJobId });
+
+      if (pendingViewJobId && pendingViewJobId !== "") {
+        const isAck = isJobAcknowledged(pendingViewJobId);
+
+        if (isAck) {
+          console.log(
+            "[Animation Debug] Pending View - Already Ack, skipping",
+            { pendingViewJobId },
+          );
+          setPendingViewJobId(null);
+          return;
+        }
+
+        console.log("[Animation Debug] Pending View - Triggering Animation", {
+          pendingViewJobId,
+        });
+
+        // Decouple from render cycle to avoid cascading renders warning
+        setTimeout(() => {
+          setPendingViewJobId(null);
+          setShowCompletionAnimation(true);
+          setCurrentAnalysisJobId(pendingViewJobId);
+        }, 0);
+
         // Trigger the completion flow immediately
-        setTimeout(() => setIsWaitingForRefresh(true), 0);
+        setTimeout(() => {
+          console.log(
+            "[Animation Debug] Pending View - Setting isWaitingForRefresh(true)",
+          );
+          setIsWaitingForRefresh(true);
+        }, 50);
       }
     }
-  }, [projectId]);
+  }, [projectId, pendingViewJobId, isJobAcknowledged, setPendingViewJobId]);
 
   // 분석 중인데 스냅샷이 없으면 현재 데이터를 스냅샷으로 저장
   // (에디터에서 분석을 시작한 경우 스냅샷이 없을 수 있음)
   useEffect(() => {
     if (!isPolling || !projectId) return;
 
-    // 만약 이미 확인된 분석이라면 (acknowledged),
-    // 분석 중이더라도 다시 스냅샷을 찍거나 플래그를 리셋하지 않음 (새로고침 루프 방지)
-    if (
-      sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true"
-    ) {
-      return;
-    }
-
     // 이미 스냅샷이 있으면 무시
     if (snapshotRef.current) return;
 
-    // sessionStorage에 스냅샷이 있는지 확인
-    try {
-      const stored = sessionStorage.getItem(`analysis_snapshot_${projectId}`);
-      if (stored) return; // 이미 저장된 스냅샷이 있음
-    } catch {
-      // ignore
-    }
+    // sessionStorage 대신 store 사용
+    const storedSnapshot = analysisSnapshots[projectId];
+    if (storedSnapshot) return; // 이미 저장된 스냅샷이 있음
 
     // 캐릭터 데이터가 로드된 후에만 스냅샷 저장
     if (characters.length === 0) return;
@@ -174,16 +191,15 @@ export default function WorldPage() {
     };
     snapshotRef.current = snapshot;
 
-    try {
-      sessionStorage.setItem(
-        `analysis_snapshot_${projectId}`,
-        JSON.stringify(snapshot),
-      );
-      sessionStorage.setItem(`analysis_acknowledged_${projectId}`, "false");
-    } catch (e) {
-      console.warn("Failed to save snapshot to sessionStorage", e);
-    }
-  }, [isPolling, projectId, characters, links]);
+    setAnalysisSnapshot(projectId, snapshot);
+  }, [
+    isPolling,
+    projectId,
+    characters,
+    links,
+    analysisSnapshots,
+    setAnalysisSnapshot,
+  ]);
 
   const analyzeMutation = useAnalyzeStory();
 
@@ -200,18 +216,10 @@ export default function WorldPage() {
     };
     snapshotRef.current = snapshot;
 
-    // Persist to sessionStorage to survive page reloads
-    try {
-      sessionStorage.setItem(
-        `analysis_snapshot_${projectId}`,
-        JSON.stringify(snapshot),
-      );
-      // Reset flags for new session
-      sessionStorage.setItem(`analysis_acknowledged_${projectId}`, "false");
-      sessionStorage.removeItem(`analysis_pending_view_${projectId}`);
-    } catch (e) {
-      console.warn("Failed to save snapshot to sessionStorage", e);
-    }
+    // Persist to store to survive page reloads
+    setAnalysisSnapshot(projectId, snapshot);
+    // Reset pending view for new session
+    setPendingViewJobId(null);
 
     // 만약 버퍼에 변경사항이 있다면, 단순히 전체 분석을 새로 날리는 게 아니라
     // 변경사항 점검을 포함한 triggerAnalysis 호출을 우선함
@@ -241,84 +249,130 @@ export default function WorldPage() {
 
   // Effect: Calculate Diff when Data Refreshes after Analysis
   useEffect(() => {
-    if (isWaitingForRefresh && !isPolling) {
-      // guard: Check acknowledgement or if modal is already open to prevent loop
-      const isAck =
-        projectId &&
-        sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true";
-      if (isAck || isAnalysisModalOpen) {
-        setTimeout(() => setIsWaitingForRefresh(false), 0);
-        return;
-      }
+    const isAck = currentAnalysisJobId
+      ? isJobAcknowledged(currentAnalysisJobId)
+      : false;
 
-      // 1. Try to get snapshot from Ref
-      let prev = snapshotRef.current;
+    console.log("[Animation Debug] Diff Effect Check", {
+      isWaitingForRefresh,
+      isPolling,
+      isCheckingJobStatus,
+      currentAnalysisJobId,
+      showCompletionAnimation,
+      isAck,
+      isAnalysisModalOpen,
+      animatingRef: animatingJobIdRef.current,
+    });
 
-      // 2. If missing (e.g. reload), try SessionStorage
-      if (!prev && projectId) {
-        try {
-          const stored = sessionStorage.getItem(
-            `analysis_snapshot_${projectId}`,
-          );
-          if (stored) {
-            prev = JSON.parse(stored);
-          }
-        } catch (e) {
-          console.error("Failed to restore snapshot from storage", e);
-        }
-      }
+    if (!isWaitingForRefresh || isPolling || isCheckingJobStatus) return;
 
-      // 3. Fallback to empty (Fresh Start)
-      if (!prev) {
-        prev = { characters: [], links: [] };
-      }
-
-      const currentChars = characters;
-      const currentLinks = links;
-
-      const diff = calculateDiffFromSnapshot(
-        prev.characters,
-        prev.links,
-        currentChars,
-        currentLinks,
+    if (isAck || isAnalysisModalOpen) {
+      console.log(
+        "[Animation Debug] Diff Effect - Skipping (isAck or isModalOpen)",
       );
-
-      // IMPORTANT: Reset wait state IMMEDIATELY to prevent redundant triggers
-      // before the async setStates below can finish.
-      // Fix: Wrap state updates in setTimeout to avoid "set-state-in-effect" warning
-      setTimeout(() => {
-        setIsWaitingForRefresh(false);
-        setAnalysisDiff(diff);
-
-        // Set highlighting
-        const namesToHighlight = [
-          ...diff.newCharacters.map((c) => c.profile.name),
-          ...diff.updatedCharacters.map((u) => {
-            const char = currentChars.find((c) => c._id === u.id);
-            return char?.profile.name || "";
-          }),
-        ].filter(Boolean);
-        setPendingHighlightNames(namesToHighlight);
-
-        snapshotRef.current = null; // Clear snapshot ref
-        if (projectId) {
-          sessionStorage.removeItem(`analysis_snapshot_${projectId}`); // Clear storage
-        }
-      }, 0);
-
-      // Open modal
-      setTimeout(() => {
-        setShowCompletionAnimation(false);
-        setIsAnalysisModalOpen(true);
-      }, 1500);
+      setTimeout(() => setIsWaitingForRefresh(false), 0);
+      return;
     }
+
+    // Guard: 만약 이미 이 작업으로 애니메이션 타이머가 돌고 있다면 중복 실행 방지
+    // 데이터 로드 과정에서 characters/links가 변하면서 이 effect가 재실행될 수 있음.
+    // clearTimeout으로 인해 타이머가 초기화되어 결과창이 안 뜨는 문제를 해결.
+    if (
+      currentAnalysisJobId &&
+      animatingJobIdRef.current === currentAnalysisJobId
+    ) {
+      console.log(
+        "[Animation Debug] Diff Effect - Already animating this job, ignoring update",
+        currentAnalysisJobId,
+      );
+      return;
+    }
+    animatingJobIdRef.current = currentAnalysisJobId;
+
+    // 1. Try to get snapshot from Ref
+    let prev = snapshotRef.current;
+
+    // 2. If missing (e.g. reload), try store (persistent)
+    if (!prev && projectId) {
+      prev = analysisSnapshots[projectId];
+    }
+
+    // 3. Fallback to empty (Fresh Start)
+    if (!prev) {
+      prev = { characters: [], links: [] };
+    }
+
+    const currentChars = characters;
+    const currentLinks = links;
+
+    const diff = calculateDiffFromSnapshot(
+      prev.characters,
+      prev.links,
+      currentChars,
+      currentLinks,
+    );
+
+    // IMPORTANT: Reset wait state IMMEDIATELY to prevent redundant triggers
+    // before the async setStates below can finish.
+    // Fix: Wrap state updates in setTimeout to avoid "set-state-in-effect" warning
+    // Enforce minimum display time for "Analysis Complete" animation (2 seconds)
+    const minDisplayTime = 2000;
+
+    const timer = setTimeout(() => {
+      console.log("[Animation Debug] Timer Finished - Opening Modal", {
+        jobId: currentAnalysisJobId,
+        isDiffEmpty:
+          !diff ||
+          (diff.newCharacters.length === 0 &&
+            diff.updatedCharacters.length === 0 &&
+            diff.newRelations.length === 0),
+      });
+
+      // Synchronous updates to ensure UI consistency
+      setIsWaitingForRefresh(false);
+      setAnalysisDiff(diff);
+
+      // Set highlighting
+      const namesToHighlight = [
+        ...diff.newCharacters.map((c) => c.profile.name),
+        ...diff.updatedCharacters.map((u) => {
+          const char = currentChars.find((c) => c._id === u.id);
+          return char?.profile.name || "";
+        }),
+      ].filter(Boolean);
+      setPendingHighlightNames(namesToHighlight);
+
+      snapshotRef.current = null; // Clear snapshot ref
+      if (projectId) {
+        clearAnalysisSnapshot(projectId); // Clear store
+      }
+
+      // Open modal immediately after the animation delay
+      setShowCompletionAnimation(false);
+      setIsAnalysisModalOpen(true);
+      animatingJobIdRef.current = null; // 타이머 종료 후 초기화
+    }, minDisplayTime);
+
+    return () => {
+      // 2024-01-16 Fix: 데이터 변경으로 인해 Effect가 재실행될 때
+      // 이미 같은 Job으로 애니메이션이 돌고 있다면 타이머를 초기화하지 않음.
+      if (animatingJobIdRef.current !== currentAnalysisJobId) {
+        clearTimeout(timer);
+      }
+    };
   }, [
     isWaitingForRefresh,
     isPolling,
+    isCheckingJobStatus,
     characters,
     links,
     projectId,
     isAnalysisModalOpen,
+    currentAnalysisJobId,
+    analysisSnapshots,
+    clearAnalysisSnapshot,
+    isJobAcknowledged,
+    showCompletionAnimation,
   ]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -469,7 +523,6 @@ export default function WorldPage() {
     const targetChar = characters.find((c) => c._id === targetId);
 
     if (!sourceChar || !targetChar) {
-      console.warn("캐릭터를 찾을 수 없습니다:", sourceId, targetId);
       return;
     }
 
@@ -531,7 +584,8 @@ export default function WorldPage() {
         >
           {/* Analysis Overlay (Scoped to Graph) */}
           <AnimatePresence>
-            {((isPolling && currentJobType !== "image") ||
+            {(isCheckingJobStatus ||
+              (isPolling && currentJobType !== "image") ||
               isDebugAnalyzing ||
               showCompletionAnimation) && (
               <motion.div
@@ -873,13 +927,12 @@ export default function WorldPage() {
           onClose={() => {
             setIsAnalysisModalOpen(false);
             setAnalysisDiff(null);
-            // Mark as acknowledged so notifications stop appearing
-            if (projectId) {
-              sessionStorage.setItem(
-                `analysis_acknowledged_${projectId}`,
-                "true",
-              );
+            // Acknowledge this job to prevent re-animation on reload/navigation
+            if (currentAnalysisJobId) {
+              acknowledgeJob(currentAnalysisJobId);
             }
+            setCurrentAnalysisJobId(null);
+            animatingJobIdRef.current = null;
           }}
           diff={analysisDiff}
           characters={characters}

--- a/src/pages/world/WorldPage.tsx
+++ b/src/pages/world/WorldPage.tsx
@@ -145,6 +145,14 @@ export default function WorldPage() {
   useEffect(() => {
     if (!isPolling || !projectId) return;
 
+    // 만약 이미 확인된 분석이라면 (acknowledged),
+    // 분석 중이더라도 다시 스냅샷을 찍거나 플래그를 리셋하지 않음 (새로고침 루프 방지)
+    if (
+      sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true"
+    ) {
+      return;
+    }
+
     // 이미 스냅샷이 있으면 무시
     if (snapshotRef.current) return;
 
@@ -234,8 +242,14 @@ export default function WorldPage() {
   // Effect: Calculate Diff when Data Refreshes after Analysis
   useEffect(() => {
     if (isWaitingForRefresh && !isPolling) {
-      // [Fix] Allow diff calculation even if snapshot is missing (treat as fresh start)
-      // Check if data seems "fresh" or different (or just assume it is after query invalidation)
+      // guard: Check acknowledgement or if modal is already open to prevent loop
+      const isAck =
+        projectId &&
+        sessionStorage.getItem(`analysis_acknowledged_${projectId}`) === "true";
+      if (isAck || isAnalysisModalOpen) {
+        setTimeout(() => setIsWaitingForRefresh(false), 0);
+        return;
+      }
 
       // 1. Try to get snapshot from Ref
       let prev = snapshotRef.current;
@@ -269,8 +283,11 @@ export default function WorldPage() {
         currentLinks,
       );
 
+      // IMPORTANT: Reset wait state IMMEDIATELY to prevent redundant triggers
+      // before the async setStates below can finish.
       // Fix: Wrap state updates in setTimeout to avoid "set-state-in-effect" warning
       setTimeout(() => {
+        setIsWaitingForRefresh(false);
         setAnalysisDiff(diff);
 
         // Set highlighting
@@ -283,8 +300,6 @@ export default function WorldPage() {
         ].filter(Boolean);
         setPendingHighlightNames(namesToHighlight);
 
-        // Reset wait state
-        setIsWaitingForRefresh(false);
         snapshotRef.current = null; // Clear snapshot ref
         if (projectId) {
           sessionStorage.removeItem(`analysis_snapshot_${projectId}`); // Clear storage
@@ -297,7 +312,14 @@ export default function WorldPage() {
         setIsAnalysisModalOpen(true);
       }, 1500);
     }
-  }, [isWaitingForRefresh, isPolling, characters, links, projectId]);
+  }, [
+    isWaitingForRefresh,
+    isPolling,
+    characters,
+    links,
+    projectId,
+    isAnalysisModalOpen,
+  ]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(

--- a/src/services/settingService.ts
+++ b/src/services/settingService.ts
@@ -15,15 +15,70 @@ export interface ProjectSetting {
   createdAt?: string;
 }
 
+// Helper to safe parse or return object
+
+interface BackendSetting {
+  id?: string;
+  _id?: string;
+  setting_id?: string;
+  project_id?: string;
+  projectId?: string;
+  name?: string;
+  type?: string;
+  category?: string;
+  description?: string;
+  atmosphere?: string;
+  lighting?: string;
+  time_of_day?: string;
+  timeOfDay?: string;
+  art_style?: string;
+  artStyle?: string;
+  visual_background?: string;
+  visualBackground?: string;
+  created_at?: string;
+  createdAt?: string;
+  [key: string]: unknown;
+}
+
+function transformBackendSetting(backend: BackendSetting): ProjectSetting {
+  return {
+    id: (backend.id || backend._id || backend.setting_id || "") as string,
+    // [Fix] Map snake_case project_id to camelCase if needed, though interface doesn't strictly demand it yet
+    // but useful if we extend ProjectSetting to include projectId
+    name: (backend.name as string) || "Untitled Setting",
+    type: (backend.type as string) || "place",
+    category: (backend.category as string) || "place",
+    description: (backend.description as string) || "",
+    atmosphere: (backend.atmosphere as string) || "",
+    lighting: (backend.lighting as string) || "",
+    time_of_day:
+      (backend.time_of_day as string) || (backend.timeOfDay as string) || "",
+    art_style:
+      (backend.art_style as string) || (backend.artStyle as string) || "",
+    visual_background:
+      (backend.visual_background as string) ||
+      (backend.visualBackground as string) ||
+      "",
+    createdAt:
+      (backend.created_at as string) || (backend.createdAt as string) || "",
+  };
+}
+
 export const settingService = {
   /**
    * Get all settings (backgrounds/places) for a project
    * Endpoint: /api/projects/{projectId}/settings
    */
   getAll: async (projectId: string) => {
-    const response = await api.get<ApiResponse<ProjectSetting[]>>(
+    const response = await api.get<ApiResponse<BackendSetting[]>>(
       `/projects/${projectId}/settings`,
     );
-    return response.data;
+
+    // Transform backend data
+    const settings = Array.isArray(response.data.data)
+      ? response.data.data.map(transformBackendSetting)
+      : [];
+
+    return { ...response.data, data: settings };
   },
 };

--- a/src/stores/useAnalysisBufferStore.ts
+++ b/src/stores/useAnalysisBufferStore.ts
@@ -5,6 +5,7 @@
  * 임계치 도달 또는 페이지 이탈 시 flush하여 분석을 트리거합니다.
  */
 
+import { useState, useEffect } from "react";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -132,17 +133,26 @@ export const useAnalysisBufferStore = create<AnalysisBufferStore>()(
             state.processedConflicts = {}; // 프로젝트 변경 시 초기화
             // state.lastAnalyzedHashes = {}; // 해시 유지 (새로고침/프로젝트 전환 시 재분석 방지)
 
-            if (projectId && state.activeJobs[projectId]?.length > 0) {
-              const jobs = state.activeJobs[projectId];
+            // 새로고침 시 진행 중인 Job이 있으면 상태 유지
+            const hasActiveJobs =
+              projectId &&
+              (state.activeJobs[projectId]?.length > 0 ||
+                state.activeAnalysisJobs[projectId]?.length > 0);
+
+            if (hasActiveJobs) {
+              const jobs =
+                state.activeJobs[projectId!] ||
+                state.activeAnalysisJobs[projectId!];
               state.currentJobId = jobs[jobs.length - 1]; // 가장 최신 Job을 일단 표시
               state.currentJobType = "analysis"; // Default to analysis on reload if unknown
+              // activeJobs가 있으면 isAnalyzing 유지 (새로고침 시 SSE 재연결까지 상태 보존)
+              state.isAnalyzing = true;
             } else {
               state.currentJobId = null;
               state.currentJobType = null;
               state.currentJobTargetId = null;
+              state.isAnalyzing = false;
             }
-            // isAnalyzing은 persist에서 복원되어도 useProjectAnalysis의 mount status check 결과를 따르도록 함
-            state.isAnalyzing = false;
           }
         });
       },
@@ -471,4 +481,28 @@ export const useAnalysisBufferStore = create<AnalysisBufferStore>()(
 export const ANALYSIS_BUFFER_CONFIG = {
   MIN_CHARS: MIN_CHARS_FOR_AUTO_FLUSH,
   MIN_INTERVAL_MS,
+};
+
+/**
+ * Hydration 완료 여부를 반환하는 훅
+ * IndexedDB에서 상태 복원이 완료되었는지 확인
+ */
+export const useAnalysisBufferHydrated = (): boolean => {
+  const [hydrated, setHydrated] = useState(() => {
+    return useAnalysisBufferStore.persist.hasHydrated();
+  });
+
+  useEffect(() => {
+    // persist 미들웨어의 onFinishHydration 콜백 등록
+    const unsubFinishHydration =
+      useAnalysisBufferStore.persist.onFinishHydration(() => {
+        setHydrated(true);
+      });
+
+    return () => {
+      unsubFinishHydration();
+    };
+  }, []);
+
+  return hydrated;
 };

--- a/src/stores/useAnalysisBufferStore.ts
+++ b/src/stores/useAnalysisBufferStore.ts
@@ -12,6 +12,8 @@ import { immer } from "zustand/middleware/immer";
 import { get, set as idbSet, del } from "idb-keyval";
 import type { StateStorage } from "zustand/middleware";
 import type { ConsistencyReport } from "@/types/analysisResult";
+import type { Character } from "@/types/character";
+import type { RelationshipLink } from "@/types/characterGraph";
 import { calculateContentHash } from "@/utils/hashUtils";
 
 // IndexedDB 스토리지 어댑터
@@ -26,6 +28,11 @@ const storage: StateStorage = {
     await del(name);
   },
 };
+
+export interface AnalysisSnapshot {
+  characters: Character[];
+  links: RelationshipLink[];
+}
 
 // 버퍼 청크 타입
 export interface BufferChunk {
@@ -56,6 +63,9 @@ interface AnalysisBufferStore {
   pendingDocuments: Record<string, string>; // 분석 요청된 문서: documentId -> contentHash (분석 완료 전까지 유지)
   lastConsistencyReport: ConsistencyReport | null; // 마지막 분석 결과 (일관성 리포트)
   processedConflicts: Record<string, "resolved" | "ignored" | "deleted">; // 처리된 이슈 관리
+  pendingViewJobId: string | null; // 사용자가 아직 확인하지 못한 분석 결과 ID
+  analysisSnapshots: Record<string, AnalysisSnapshot>; // projectId -> snapshot (characters, links)
+  acknowledgedJobIds: string[]; // 확인된 분석 작업 ID 목록
 
   // 액션
   setProjectId: (projectId: string | null) => void;
@@ -97,6 +107,11 @@ interface AnalysisBufferStore {
   clearProcessedConflicts: () => void;
   // 강제 초기화
   resetAnalysis: () => void;
+  setPendingViewJobId: (id: string | null) => void;
+  setAnalysisSnapshot: (projectId: string, snapshot: AnalysisSnapshot) => void;
+  clearAnalysisSnapshot: (projectId: string) => void;
+  acknowledgeJob: (jobId: string) => void;
+  isJobAcknowledged: (jobId: string) => boolean;
 
   // 유틸리티
   getBufferSummary: () => { charCount: number; documentCount: number };
@@ -121,6 +136,9 @@ export const useAnalysisBufferStore = create<AnalysisBufferStore>()(
       pendingDocuments: {}, // 분석 요청된 문서 트래킹
       lastConsistencyReport: null,
       processedConflicts: {},
+      pendingViewJobId: null,
+      analysisSnapshots: {},
+      acknowledgedJobIds: [],
 
       setProjectId: (projectId) => {
         set((state) => {
@@ -391,10 +409,41 @@ export const useAnalysisBufferStore = create<AnalysisBufferStore>()(
           state.isAnalyzing = false;
           state.progress = 0;
           state.pendingDocuments = {};
+          state.pendingViewJobId = null; // 초기화
           if (state.projectId) {
             delete state.activeJobs[state.projectId];
           }
         });
+      },
+
+      setPendingViewJobId: (id) => {
+        set((state) => {
+          state.pendingViewJobId = id;
+        });
+      },
+
+      setAnalysisSnapshot: (projectId, snapshot) => {
+        set((state) => {
+          state.analysisSnapshots[projectId] = snapshot;
+        });
+      },
+
+      clearAnalysisSnapshot: (projectId) => {
+        set((state) => {
+          delete state.analysisSnapshots[projectId];
+        });
+      },
+
+      acknowledgeJob: (jobId) => {
+        set((state) => {
+          if (!state.acknowledgedJobIds.includes(jobId)) {
+            state.acknowledgedJobIds.push(jobId);
+          }
+        });
+      },
+
+      isJobAcknowledged: (jobId) => {
+        return get().acknowledgedJobIds.includes(jobId);
       },
 
       getBufferSummary: () => {
@@ -461,6 +510,9 @@ export const useAnalysisBufferStore = create<AnalysisBufferStore>()(
         pendingDocuments: state.pendingDocuments,
         lastConsistencyReport: state.lastConsistencyReport,
         processedConflicts: state.processedConflicts,
+        pendingViewJobId: state.pendingViewJobId,
+        analysisSnapshots: state.analysisSnapshots,
+        acknowledgedJobIds: state.acknowledgedJobIds,
       }),
       // 기존 저장 상태에 새 필드가 없을 때 기본값 적용
       merge: (persistedState, currentState) => {


### PR DESCRIPTION
## 📋 변경 사항

### 1. 분석 완료 애니메이션 및 모달 출력 안정화

- **Race Condition 해결**: 세계관 페이지에서 데이터 갱신 시 `useEffect`가 재실행되어 타이머가 취소되던 문제를 `animatingJobIdRef` 가드를 통해 해결했습니다.
- **성공 연출 보장**: "Scanning" 상태에서 "Success" (성공) 연출이 최소 2초간 유지된 후 결과 모달이 뜨도록 보장했습니다.

### 2. 분석 상태 관리 개선 (영속성 도입)

- **Persistent Store (IndexedDB)**: `useAnalysisBufferStore`에 `Zustand persist`를 적용하여, 페이지 새로고침이나 에디터->세계관 이동 시에도 분석 상태(스냅샷, 대기 Job ID)가 유실되지 않도록 수정했습니다.

### 3. 최신 `dev` 브랜치 병합 및 최적화

- **Merge dev**: 최신 `dev` 브랜치의 글자수 통계 기능 및 UI 개편 사항을 병합했습니다.
- **린트 및 타입 경고 해결**: 병합 과정에서 발생한 린트 경고(누락된 의존성, restricted import)를 수정하고, 디자인 시스템의 `Button` 컴포넌트(`intent` prop)를 올바르게 적용했습니다.

## 📁 주요 변경 파일

- `src/pages/world/WorldPage.tsx`
- `src/pages/editor/EditorPage.tsx`
- `src/stores/useAnalysisBufferStore.ts`
- `src/pages/stats/StatsPage.tsx`

## ✅ 체크리스트

- [x] 빌드 성공 확인 (`npm run build`)
- [x] ESLint 및 Type Check 100% 통과
- [x] 분석 상태 영속성 및 연출 동작 확인

## 🔀 Merge 가이드

- Target: `dev`
- Squash and Merge 권장
