### PR TITLE
feat: 프로젝트 복제 기능(UI 및 연동) 구현

### DIFF
--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -39,9 +39,7 @@ interface BookCardProps {
   progress: number;
   lastEdited: string;
   onClick?: () => void;
-  onAction?: (
-    action: "rename" | "duplicate" | "delete" | "change_cover",
-  ) => void;
+  onAction?: (action: "rename" | "clone" | "delete" | "change_cover") => void;
 
   // 상태 변경 콜백
   onStatusChange?: (status: ProjectStatusType) => void;
@@ -214,7 +212,7 @@ export function BookCard({
                 <DropdownMenuItem onClick={() => onAction?.("rename")}>
                   <Edit className="mr-2 h-4 w-4" /> 이름 변경
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onAction?.("duplicate")}>
+                <DropdownMenuItem onClick={() => onAction?.("clone")}>
                   <Copy className="mr-2 h-4 w-4" /> 복제
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onAction?.("change_cover")}>

--- a/src/components/library/CloneProjectDialog.tsx
+++ b/src/components/library/CloneProjectDialog.tsx
@@ -1,0 +1,97 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCloneProject } from "@/hooks/useCloneProject";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import type { Project } from "@/types";
+
+interface CloneProjectDialogProps {
+  project: Project;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const CloneProjectDialog: React.FC<CloneProjectDialogProps> = ({
+  project,
+  open,
+  onOpenChange,
+}) => {
+  const { mutate: cloneProject, isPending } = useCloneProject();
+  const [newTitle, setNewTitle] = useState(`${project.title} (복사본)`);
+
+  const handleClone = () => {
+    if (!newTitle.trim()) {
+      console.error("프로젝트 제목을 입력해주세요.");
+      return;
+    }
+
+    cloneProject(
+      { projectId: project.id, request: { newTitle } },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setNewTitle(`${project.title} (복사본)`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>프로젝트 복제</DialogTitle>
+          <DialogDescription>
+            "{project.title}" 프로젝트를 복제합니다.
+            <br />
+            <span className="text-xs text-muted-foreground mt-2 block">
+              💡 모든 챕터, 캐릭터, 복선이 함께 복제됩니다.
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="newTitle">새 프로젝트 제목</Label>
+            <Input
+              id="newTitle"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              placeholder="복제된 프로젝트의 제목을 입력하세요"
+              disabled={isPending}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            취소
+          </Button>
+          <Button onClick={handleClone} disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                복제 중...
+              </>
+            ) : (
+              "복제"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/hooks/useCloneProject.ts
+++ b/src/hooks/useCloneProject.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import {
+  cloneProject,
+  type ProjectCloneRequest,
+} from "../services/projectService";
+
+export const useCloneProject = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      projectId,
+      request,
+    }: {
+      projectId: string;
+      request: ProjectCloneRequest;
+    }) => cloneProject(projectId, request),
+
+    onSuccess: (data) => {
+      // 프로젝트 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+
+      console.log(`프로젝트 "${data.data.title}"가 복제되었습니다.`);
+    },
+
+    onError: (error: AxiosError<{ message: string }>) => {
+      const message =
+        error.response?.data?.message || "프로젝트 복제에 실패했습니다.";
+      console.error(message);
+    },
+  });
+};

--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -24,6 +24,7 @@ import { Button } from "@stolink/ui";
 import { Input } from "@stolink/ui";
 import { BookCard } from "@/components/library/BookCard";
 import { CreateBookModal } from "@/components/library/CreateBookModal";
+import { CloneProjectDialog } from "@/components/library/CloneProjectDialog";
 import { useAuthStore } from "@/stores";
 import { cn } from "@/lib/utils";
 import { useNavigate } from "react-router-dom";
@@ -31,7 +32,6 @@ import { useNavigate } from "react-router-dom";
 import {
   useProjects,
   useDeleteProject,
-  useDuplicateProject,
   useUpdateProject,
 } from "@/hooks/useProjects";
 import { projectService } from "@/services/projectService";
@@ -45,6 +45,7 @@ import { useDocumentStore } from "@/repositories/LocalDocumentRepository";
 import { getApiData } from "@/utils/apiUtils";
 import { useUpdateProjectStatus } from "@/hooks/useUpdateProjectStatus";
 import type { ProjectStatusType } from "@/components/library/StatusChip";
+import type { Project } from "@/types/project";
 import { manuscriptService } from "@/services/manuscriptService";
 import { useManuscriptJobStore } from "@/stores/useManuscriptJobStore";
 import { useManuscriptPolling } from "@/hooks/useManuscriptPolling";
@@ -118,6 +119,10 @@ export default function LibraryPage() {
     null,
   );
 
+  // ========== 프로젝트 복제 상태 ==========
+  const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
+  const [cloneTarget, setCloneTarget] = useState<Project | null>(null);
+
   const {
     data: projectsData,
     isLoading,
@@ -126,7 +131,6 @@ export default function LibraryPage() {
   const { mutate: deleteProject, mutateAsync: deleteProjectAsync } =
     useDeleteProject();
   const { mutate: updateProjectStatus } = useUpdateProjectStatus();
-  const { mutate: duplicateProject } = useDuplicateProject();
   const { mutate: updateProject } = useUpdateProject();
 
   // ========== 원고 비동기 처리 ==========
@@ -747,9 +751,10 @@ export default function LibraryPage() {
                       setRenameTarget({ id: project.id, title: project.title });
                       setNewTitle(project.title);
                       setRenameModalOpen(true);
-                    } else if (action === "duplicate") {
+                    } else if (action === "clone") {
                       // 프로젝트 복제
-                      duplicateProject(project.id);
+                      setCloneTarget(project);
+                      setCloneDialogOpen(true);
                     } else if (action === "change_cover") {
                       // 표지 변경
                       setCoverUpdateTargetId(project.id);
@@ -987,6 +992,17 @@ export default function LibraryPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* ========== 프로젝트 복제 다이얼로그 ========== */}
+      {cloneTarget && (
+        <CloneProjectDialog
+          project={cloneTarget}
+          open={cloneDialogOpen}
+          onOpenChange={setCloneDialogOpen}
+        />
+      )}
+
+      <Footer />
     </div>
   );
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -64,4 +64,27 @@ export const projectService = {
     );
     return response.data;
   },
+
+  clone: async (id: string, request: ProjectCloneRequest) => {
+    const response = await api.post<ApiResponse<Project>>(
+      `/projects/${id}/clone`,
+      request,
+    );
+    return response.data;
+  },
+};
+
+export interface ProjectCloneRequest {
+  newTitle: string;
+}
+
+export const cloneProject = async (
+  projectId: string,
+  request: ProjectCloneRequest,
+): Promise<ApiResponse<Project>> => {
+  const response = await api.post<ApiResponse<Project>>(
+    `/projects/${projectId}/clone`,
+    request,
+  );
+  return response.data;
 };


### PR DESCRIPTION
##🚀 변경 사항
사용자가 서재에서 프로젝트를 손쉽게 복제할 수 있도록 UI와 API 연동을 구현했습니다.

## 주요 기능
Clone Dialog: 프로젝트 복제 시 새 제목을 입력받는 모달 구현 (
CloneProjectDialog
)
API 연동: 
useCloneProject
 훅을 통해 /api/projects/{id}/clone 호출
UI 통합:
프로젝트 카드(
BookCard
) 메뉴에 '복제' 옵션 추가
기존의 불안정한 
duplicate
 기능 대체
변경 상세
projectService: 
clone
 메서드 추가
BookCard
: Dropdown 메뉴 '복제' 액션 핸들러 연결
LibraryPage
: 복제 다이얼로그 상태 관리 및 이벤트 핸들링
## ✅ 체크리스트 
 프로젝트 카드 메뉴에서 '복제' 클릭 시 다이얼로그 표시
 새 제목 입력 후 복제 요청 성공 확인
 복제 성공 후 프로젝트 목록 자동 갱신 확인
 Lint 규칙 준수 (타입 에러 수정)