### PR TITLE
fix(editor): use named import for EditorSkeleton

### DIFF
--- a/src/pages/editor/components/EditorContent.tsx
+++ b/src/pages/editor/components/EditorContent.tsx
@@ -9,7 +9,7 @@ import TiptapEditor from "@/components/editor/TiptapEditor";
 import ScriveningsEditor from "@/components/editor/ScriveningsEditor";
 import OutlineView from "@/components/editor/OutlineView";
 import EmptyState from "@/components/editor/EmptyState";
-import EditorSkeleton from "@/components/editor/EditorSkeleton";
+import { EditorSkeleton } from "@/components/editor/EditorSkeleton";
 import type { TiptapEditorHandle } from "@/components/editor/TiptapEditor";
 import type { ScriveningsEditorHandle } from "@/components/editor/ScriveningsEditor";
 import type { Document } from "@/types/document";


### PR DESCRIPTION
## 📋 변경 사항

- 의  import 방식을 Default Import에서 Named Import로 수정 (빌드 에러 수정)

PR #235 머지 후 누락된 수정 사항을 반영합니다.

Closes #235 (follow-up)