### PR TITLE
feat(storybook): add UI components stories

### DIFF
--- a/src/components/characters/CharacterCard.stories.tsx
+++ b/src/components/characters/CharacterCard.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CharacterCard } from "./CharacterCard";
+
+const meta: Meta<typeof CharacterCard> = {
+  title: "Characters/CharacterCard",
+  component: CharacterCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    character: {
+      control: "object",
+    },
+    onClick: { action: "clicked" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CharacterCard>;
+
+export const Default: Story = {
+  args: {
+    character: {
+      _id: "char-1",
+      projectId: "proj-1",
+      role: "protagonist",
+      profile: {
+        name: "김철수",
+        age: "28",
+        gender: "남성",
+        occupation: "회사원",
+        backstory:
+          "평범한 회사원이던 어느 날, 이세계로 소환되어 용사가 되었다. 집으로 돌아가기 위해 마왕을 물리쳐야 한다.",
+        appearance: "검은 머리, 평범한 인상",
+        personality: "성실함, 겁이 많음",
+        goals: "집으로 귀환",
+      },
+      relationships: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    index: 0,
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    character: {
+      ...Default.args!.character!,
+      imageUrl: "https://placehold.co/300x400/png",
+    },
+  },
+};
+
+export const Antagonist: Story = {
+  args: {
+    character: {
+      ...Default.args!.character!,
+      role: "antagonist",
+      profile: {
+        ...Default.args!.character!.profile,
+        name: "마왕 자드",
+        backstory: "세상을 지배하려는 암흑의 군주.",
+      },
+    },
+  },
+};
+
+export const Mentor: Story = {
+  args: {
+    character: {
+      ...Default.args!.character!,
+      role: "mentor",
+      profile: {
+        ...Default.args!.character!.profile,
+        name: "현자 간달프",
+        backstory: "오랜 세월을 살아온 현자. 주인공을 이끈다.",
+      },
+    },
+  },
+};

--- a/src/components/characters/CharacterCard.tsx
+++ b/src/components/characters/CharacterCard.tsx
@@ -1,0 +1,77 @@
+import { roleLabels } from "@/pages/world/constants";
+import type { Character } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface CharacterCardProps {
+  character: Character;
+  onClick?: (character: Character) => void;
+  index?: number;
+}
+
+export function CharacterCard({
+  character,
+  onClick,
+  index = 0,
+}: CharacterCardProps) {
+  const name =
+    character.profile?.name ||
+    (character as { name?: string }).name ||
+    "이름 없음";
+  const backstory =
+    character.profile?.backstory ||
+    (character as { backstory?: string }).backstory;
+  const role = character.role || "other";
+
+  return (
+    <div
+      className={cn(
+        "editorial-card group cursor-pointer overflow-hidden aspect-[3/4] flex flex-col hover-lift editorial-fade-in",
+        "bg-white border border-cloud-100 rounded-xl shadow-sm hover:shadow-md transition-all duration-300",
+      )}
+      style={{ animationDelay: `${index * 50}ms` }}
+      onClick={() => onClick?.(character)}
+    >
+      {/* Image Section - 70% height */}
+      <div className="relative flex-[7] overflow-hidden bg-muted">
+        {character.imageUrl ? (
+          <>
+            <img
+              src={character.imageUrl}
+              alt={name}
+              className="w-full h-full object-cover transition-all duration-500 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+          </>
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-cloud-50 text-mocha-300">
+            <span className="text-5xl opacity-50 group-hover:opacity-70 transition-opacity transform group-hover:scale-110 duration-300">
+              {role === "protagonist"
+                ? "🦸"
+                : role === "antagonist"
+                  ? "🦹"
+                  : role === "mentor"
+                    ? "🧙"
+                    : "👤"}
+            </span>
+          </div>
+        )}
+        {/* Role Badge */}
+        <div className="absolute top-3 left-3 px-2 py-1 bg-white/90 backdrop-blur-sm rounded-md text-[10px] font-bold text-espresso-900 border border-black/5 shadow-sm uppercase tracking-wider">
+          {roleLabels[role]}
+        </div>
+      </div>
+
+      {/* Info Section - 30% height */}
+      <div className="flex-[3] p-4 bg-white flex flex-col justify-center border-t border-cloud-100 relative group-hover:bg-cloud-50/30 transition-colors">
+        <h3 className="text-base font-bold text-espresso-900 line-clamp-1 group-hover:text-mocha-600 transition-colors font-serif tracking-tight">
+          {name}
+        </h3>
+        {backstory && (
+          <p className="text-xs text-mocha-400 line-clamp-2 mt-1 leading-relaxed font-sans">
+            {backstory}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/EditorLeftSidebar.stories.tsx
+++ b/src/components/editor/EditorLeftSidebar.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import EditorLeftSidebar from "./EditorLeftSidebar";
+
+const meta: Meta<typeof EditorLeftSidebar> = {
+  title: "Editor/EditorLeftSidebar",
+  component: EditorLeftSidebar,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    isOpen: { control: "boolean" },
+    onToggle: { action: "toggled" },
+    onSelectChapter: { action: "selected" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen flex">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EditorLeftSidebar>;
+
+const mockChapters = [
+  {
+    id: "folder-1",
+    title: "제1장: 시작",
+    type: "chapter" as const,
+    children: [
+      { id: "doc-1", title: "1화. 소환", type: "section" as const },
+      { id: "doc-2", title: "2화. 각성", type: "section" as const },
+    ],
+  },
+  {
+    id: "folder-2",
+    title: "제2장: 모험",
+    type: "chapter" as const,
+    children: [
+      { id: "doc-3", title: "3화. 만남", type: "section" as const },
+      { id: "doc-4", title: "4화. 위기", type: "section" as const },
+    ],
+  },
+];
+
+export const Expanded: Story = {
+  args: {
+    isOpen: true,
+    chapters: mockChapters,
+    selectedChapterId: "doc-1",
+    projectTitle: "용사님 비켜주세요",
+    totalChars: 12500,
+    onAddChapter: async () => null,
+    onRenameChapter: () => {},
+    onDeleteChapter: () => {},
+    onReorderChapter: () => {},
+    onMoveToFolder: () => {},
+  },
+};
+
+export const Collapsed: Story = {
+  args: {
+    ...Expanded.args,
+    isOpen: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    ...Expanded.args,
+    chapters: [],
+    projectTitle: "새 프로젝트",
+    totalChars: 0,
+  },
+};

--- a/src/pages/editor/components/EditorContent.stories.tsx
+++ b/src/pages/editor/components/EditorContent.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { EditorContent } from "./EditorContent";
+import type { Document } from "@/types/document";
+
+const meta: Meta<typeof EditorContent> = {
+  title: "Editor/EditorContent",
+  component: EditorContent,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full bg-paper">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EditorContent>;
+
+const mockDocuments: Document[] = [
+  {
+    id: "folder-1",
+    projectId: "p1",
+    title: "Chapter 1",
+    type: "folder",
+    children: [
+      {
+        id: "doc-1",
+        projectId: "p1",
+        title: "Scene 1",
+        type: "text",
+        content: "It was a dark and stormy night...",
+      },
+    ],
+  },
+] as unknown as Document[];
+
+const baseArgs = {
+  selectedFolderId: "folder-1",
+  selectedSectionId: "doc-1",
+  projectId: "p1",
+  isFocusMode: false,
+  currentContent: "<h1>Chapter 1</h1><p>It was a dark and stormy night...</p>",
+  currentSectionTitle: "Scene 1",
+  onCharacterCountChange: () => {},
+  onContentChange: () => {},
+  documents: mockDocuments,
+  isDemo: true,
+  splitView: { enabled: false, direction: "horizontal" as const },
+  viewMode: "editor" as const,
+};
+
+export const EditorMode: Story = {
+  args: {
+    ...baseArgs,
+  },
+};
+
+export const SplitView: Story = {
+  args: {
+    ...baseArgs,
+    splitView: { enabled: true, direction: "vertical" as const },
+  },
+};

--- a/src/pages/world/WorldPage.tsx
+++ b/src/pages/world/WorldPage.tsx
@@ -13,7 +13,6 @@ import type {
   RelationshipLink,
   CharacterRelationship,
 } from "@/types";
-import { roleLabels } from "./constants";
 
 import {
   AnalysisSummaryModal,
@@ -43,6 +42,7 @@ import { Button } from "@stolink/ui";
 import { EmptyIndicator } from "./components/EmptyIndicator";
 import { ForeshadowingPanel } from "./components/ForeshadowingPanel";
 import { NetworkDetailPanelD3 } from "./components/NetworkDetailPanelD3";
+import { CharacterCard } from "@/components/characters/CharacterCard";
 
 import { useProjectEvents } from "@/hooks/useEvents";
 import { useRelationshipLinks } from "@/hooks/useRelationshipLinks";
@@ -879,58 +879,12 @@ export default function WorldPage() {
 
               <div className="pt-20 px-8 pb-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
                 {characters.map((character, index) => (
-                  <div
+                  <CharacterCard
                     key={`${character._id || (character as { id?: string }).id || "char"}-${index}`}
-                    className="editorial-card group cursor-pointer overflow-hidden aspect-[3/4] flex flex-col hover-lift editorial-fade-in"
-                    style={{ animationDelay: `${index * 50}ms` }}
-                    onClick={() => handleCardClick(character)}
-                  >
-                    {/* Image Section - 70% height */}
-                    <div className="relative flex-[7] overflow-hidden bg-muted">
-                      {character.imageUrl ? (
-                        <>
-                          <img
-                            src={character.imageUrl}
-                            alt={character.profile?.name || ""}
-                            className="w-full h-full object-cover transition-all duration-500 group-hover:scale-105"
-                          />
-                          <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                        </>
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <span className="text-5xl opacity-50 group-hover:opacity-70 transition-opacity">
-                            {character.role === "protagonist"
-                              ? "🦸"
-                              : character.role === "antagonist"
-                                ? "🦹"
-                                : character.role === "mentor"
-                                  ? "🧙"
-                                  : "👤"}
-                          </span>
-                        </div>
-                      )}
-                      {/* Role Badge */}
-                      <div className="floating-badge">
-                        {roleLabels[character.role || "other"]}
-                      </div>
-                    </div>
-
-                    {/* Info Section - 30% height */}
-                    <div className="flex-[3] p-4 bg-paper flex flex-col justify-center border-t border-cloud-100">
-                      <h3 className="text-base font-bold text-espresso-900 line-clamp-1 group-hover:text-mocha-500 transition-colors">
-                        {character.profile?.name ||
-                          (character as { name?: string }).name ||
-                          "이름 없음"}
-                      </h3>
-                      {(character.profile?.backstory ||
-                        (character as { backstory?: string }).backstory) && (
-                        <p className="text-xs text-mocha-400 line-clamp-2 mt-1 leading-relaxed">
-                          {character.profile?.backstory ||
-                            (character as { backstory?: string }).backstory}
-                        </p>
-                      )}
-                    </div>
-                  </div>
+                    character={character}
+                    index={index}
+                    onClick={handleCardClick}
+                  />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## 🎨 Storybook Expansion

- Added stories for core components to enable Visual Regression Testing (Chromatic).
- Components covered:
  - `CharacterCard`: Default, With Image, Antagonist, Mentor
  - `EditorLeftSidebar`: Expanded, Collapsed
  - `EditorContent`: Editor Mode, Split View
- Refactored `CharacterCard` into a reusable component.

This PR prepares the codebase for better UI testing and consistency checks.